### PR TITLE
Updating Lifecycle Badge Location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Lifecycle:Experimental](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/citz-HybridWorkplace)
 # CITZ HybridWorkplace
 
 
@@ -70,8 +71,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
-
-## Lifecycle
-
-[![Lifecycle:Experimental](https://img.shields.io/badge/Lifecycle-Experimental-339999)](https://github.com/bcgov/citz-HybridWorkplace)
-


### PR DESCRIPTION
We should be displaying our badges as the first thing seen on our repo - fixing that with this PR.