### PR TITLE
Fixed env-config.js creating variables for empty lines in env-template

### DIFF
--- a/app/client/env.sh
+++ b/app/client/env.sh
@@ -15,6 +15,8 @@ do
   if printf '%s\n' "$line" | grep -q -e '='; then
     varname=$(printf '%s\n' "$line" | sed -e 's/=.*//')
     varvalue=$(printf '%s\n' "$line" | sed -e 's/^[^=]*=//')
+  else
+    continue
   fi
 
   # Read value of current variable if exists as Environment variable


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- env-config was creating variables for empty lines or comments when reading the env-template

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested cat on env-config.js in frontend

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
