### PR TITLE
Hwp-211: communitieslist, frontend env-variables working in development

### DIFF
--- a/app/client/Dockerfile
+++ b/app/client/Dockerfile
@@ -13,6 +13,8 @@ RUN npm run build
 FROM nginx:alpine
 WORKDIR /usr/share/nginx/html
 
+ARG env_file_to_copy
+
 # Removes the default static files
 RUN rm -rf ./*
 RUN rm /etc/nginx/conf.d/default.conf
@@ -21,7 +23,11 @@ COPY app/client/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /usr/src/app/build /usr/share/nginx/html
 
 COPY app/client/./env.sh .
+
+# Production
 COPY .env-template .env
+# Development
+#COPY .env .env
 
 # Add bash
 RUN apk add --no-cache bash

--- a/app/client/README.md
+++ b/app/client/README.md
@@ -2,6 +2,10 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Development vs. Production
+
+To get env variables to work in development uncomment the line in Dockerfile copying .env file and comment out line copying .env-template. For production to the reverse of this.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/app/client/env.sh
+++ b/app/client/env.sh
@@ -20,7 +20,7 @@ do
   fi
 
   # Read value of current variable if exists as Environment variable
-  value=$(printf '%s\n' "${varname}")
+  value=$(printf '%s\n' "${varvalue}")
   # Otherwise use value from .env file
   [[ -z $value ]] && value=${varvalue}
   # Fix the line ending if it is a windows one
@@ -28,7 +28,6 @@ do
   
   # Append configuration property to JS file
   echo "  $varname: \"$value\"," >> ./env-config.js
-  #echo '  API_REF: "http://localhost:5000/api"' >> ./env-config.js
 done < .env
 
 echo "}" >> ./env-config.js

--- a/app/client/src/actions/communityActions.js
+++ b/app/client/src/actions/communityActions.js
@@ -24,7 +24,7 @@ import { GET_COMMUNITIES, ADD_COMMUNITY } from "./types";
 
 
 export const getCommunities = () => dispatch => {
-        fetch(`${process.env.API_REF}/Community`)
+        fetch(`${window._env_.API_REF}/Community`)
             .then(res => res.json())
             .then(communities => dispatch({
                 type: GET_COMMUNITIES,

--- a/app/client/src/components/communitiesList.js
+++ b/app/client/src/components/communitiesList.js
@@ -1,0 +1,68 @@
+/* 
+ Copyright © 2022 Province of British Columbia
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/**
+ * Application entry point
+ * @author [Brady Mitchell](braden.jr.mitch@gmail.com)
+ * @module
+ */
+
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import { getCommunities } from '../actions/communityActions';
+import PropTypes from 'prop-types';
+import Paper from '@mui/material/Paper';
+
+const CommunitiesList = (props) => {
+
+  useEffect(() => {
+    communities.getCommunities()
+  }, [props])
+
+  return (
+    <div>
+      {
+        props.communities.map(community => (
+          <div key={community._id}>
+            <Paper
+              sx={{
+                px: 1,
+                py: 0,
+                margin: 'auto'
+              }}
+              variant="outlined"
+              square>
+              <h3>{community.title}</h3>
+              <p>{community.description}</p>
+            </Paper>
+          </div>
+        ))
+      }
+    </div>
+  )
+}
+
+CommunitiesList.propTypes = {
+  getCommunities: PropTypes.func.isRequired,
+  communities: PropTypes.array.isRequired
+}
+
+const mapStateToProps = state => ({
+  communities: state.communities.items
+
+});
+
+export default connect(mapStateToProps, { getCommunities })(CommunitiesList);

--- a/app/client/src/components/communitiesList.js
+++ b/app/client/src/components/communitiesList.js
@@ -29,7 +29,7 @@ import Paper from '@mui/material/Paper';
 const CommunitiesList = (props) => {
 
   useEffect(() => {
-    communities.getCommunities()
+    props.getCommunities()
   }, [props])
 
   return (

--- a/app/client/src/components/createCommunity.js
+++ b/app/client/src/components/createCommunity.js
@@ -23,7 +23,7 @@
  import jwt_decode from "jwt-decode";
  import { useNavigate } from 'react-router-dom';
  import { useDispatch } from 'react-redux';
- import { createCommunity } from '../actions/communityActons';
+ import { createCommunity } from '../actions/communityActions';
  
  const CreateCommunity = () => {
     const navigate = useNavigate();

--- a/app/client/src/components/joinCommunitiesList.js
+++ b/app/client/src/components/joinCommunitiesList.js
@@ -26,7 +26,7 @@
 
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { getCommunities } from '../actions/communityActons';
+import { getCommunities } from '../actions/communityActions';
 import PropTypes from 'prop-types';
 import Paper from '@mui/material/Paper';
 import Grid from '@mui/material/Grid';

--- a/app/client/src/components/modals/addPost.js
+++ b/app/client/src/components/modals/addPost.js
@@ -25,7 +25,7 @@
  import './addPost.css'
  import Paper from '@mui/material/Paper';
  import { connect } from 'react-redux';
- import { getCommunities } from '../../actions/communityActons';
+ import { getCommunities } from '../../actions/communityActions';
  import PropTypes from 'prop-types';
  import { Button } from '@mui/material';
 
@@ -35,7 +35,7 @@
     const [message, setMessage] = useState('')
 
     const userInfo = () => {
-        fetch(`${process.env.API_REF}/profile`, {
+        fetch(`${window._env_.API_REF}/profile`, {
            headers: {
                'x-access-token': localStorage.getItem('token'),
            },

--- a/app/client/src/components/newCommunity.js
+++ b/app/client/src/components/newCommunity.js
@@ -22,7 +22,7 @@
 import React, { Component, useState } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { createCommunity } from '../actions/communityActons';
+import { createCommunity } from '../actions/communityActions';
 
 const NewCommunity = (props) => {
 

--- a/app/client/src/views/communitiesPage.js
+++ b/app/client/src/views/communitiesPage.js
@@ -21,13 +21,14 @@
  */
 
 import { Link } from 'react-router-dom';
+import Communities from '../components/communitiesList';
 
 const CommunitiesPage = () => {
 
     return (
         <div>
             <h1>Communities</h1>
-
+            <Communities/>
             <br />
             <Link to='/createCommunity'>
                 <button >Create New Community</button>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,7 +9,6 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_ROOT_USERNAME}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_ROOT_PASSWORD}
-      - MONGO_INITDB_DATABASE=root-db
     volumes:
       - ./init-mongodb:/docker-entrypoint-initdb.d
       - ./init-mongodb/data:/tmp/data

--- a/init-mongodb/data/communities.json
+++ b/init-mongodb/data/communities.json
@@ -1,1 +1,9 @@
-[{}]
+[
+    {
+        "title" : "Welcome",
+        "description" : "Say hi!",
+        "creator" : "",
+        "members" : [ ],
+        "__v" : 0
+    }
+]


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- added communitiesList component 
- Dockerfile for client has a comment to differentiate production vs. development config for env variables. This will need to have a better solution but for now this allowed it to work in dev.
- change to env.sh to allow proper import of env variables in developement.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran docker-compose, checked env variables in frontend cli with cat env-config.js
Communities list does show up when rate limiting is commented out, this is a known issue that should be fixed when redux code is changed

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No

Small non breaking changes to docker-compose and client Dockerfile

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
