### PR TITLE
Changed mongo image to mongo:4

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   ###                                     MONGO DB                                          ###
   #############################################################################################
   mongodb:
-    image: "mongo:4.2.20"
+    image: "mongo:4"
     container_name: "mongodb"
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_ROOT_USERNAME}


### PR DESCRIPTION
The old mongo image, mongo:4.2.20, was not working with the health check added to the docker-compose.yaml. It would often give the error: container is unhealthy.

**REQUIRES**:
**####################################################**

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore

For change to take effect:

1. Run `docker-compose down -v` to remove all running containers
2. In Docker Desktop, delete the mongo image, and all volumes
3. Rebuild the project with `docker-compose up --build`

POSSIBLY REQUIRED:
Re-clone of the project

**####################################################**

This PR includes the following proposed change(s):

- Changed docker-compose.yaml to use mongo:4 instead of mongo:4.2.20

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [x] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
