### PR TITLE
Reverting previous test for process.env

### DIFF
--- a/app/client/src/redux/ducks/authDuck.js
+++ b/app/client/src/redux/ducks/authDuck.js
@@ -23,7 +23,7 @@ const LOGIN = "CITZ-HYBRIDWORKPLACE/AUTH/LOGIN";
 
 const apiURI =
   window._env_.REACT_APP_LOCAL_DEV === ""
-    ? `${process.env.REACT_APP_API_REF}`
+    ? `${window._env_.REACT_APP_API_REF}`
     : `http://${window._env_.REACT_APP_API_REF}:${window._env_.REACT_APP_API_PORT}`;
 
 export const login = (name, password) => async (dispatch) => {


### PR DESCRIPTION
# Description

Reverting previous test. Thought maybe process.env would possibly pull the correct env variable for api reference.
The window._env_ for REACT_APP_API_REF is not being set to the correct api ref for openshift.

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
