### PR TITLE
Sending community name in community field instead of community id

### DIFF
--- a/app/client/src/components/modals/addPost.js
+++ b/app/client/src/components/modals/addPost.js
@@ -61,8 +61,8 @@ const CreatePost = (props) => {
     setMessage(event.target.value);
   };
 
-  const onCommunityClick = (id) => {
-    setCommunity(id);
+  const onCommunityClick = (commTitle) => {
+    setCommunity(commTitle);
   };
 
   return (
@@ -93,7 +93,7 @@ const CreatePost = (props) => {
             {props.communities.map((comm) => (
               <div key={comm._id}>
                 {/* TODO: change button input for choosing community to radio  */}
-                <Button onClick={() => onCommunityClick(comm._id)} variant={`${comm._id === community ? 'contained' : 'outlined'}`}>
+                <Button onClick={() => onCommunityClick(comm.title)} variant={`${comm.title === community ? 'contained' : 'outlined'}`}>
                   {comm.title}{" "}
                 </Button>
               </div>

--- a/app/client/src/redux/ducks/authDuck.js
+++ b/app/client/src/redux/ducks/authDuck.js
@@ -17,6 +17,8 @@
  * @module
  */
 
+import jwtDecode from "jwt-decode";
+
 const SET_ACCESS_TOKEN = "CITZ-HYBRIDWORKPLACE/AUTH/SET_ACCESS_TOKEN";
 const SET_REFRESH_TOKEN = "CITZ-HYBRIDWORKPLACE/AUTH/SET_REFRESH_TOKEN";
 const LOGIN = "CITZ-HYBRIDWORKPLACE/AUTH/LOGIN";
@@ -43,9 +45,9 @@ export const login = (name, password) => async (dispatch) => {
       throw new Error(res.status + " " + res.statusText);
     }
 
-    /* Below is Commented out as backend token auth is not yet implemented*/
-
     const data = await res.json();
+    const decodedToken = jwtDecode(data.token)
+    data.user = { name: decodedToken.name, email: decodedToken.email }
 
     dispatch({
       type: LOGIN,
@@ -106,9 +108,9 @@ export function authReducer(state = initialState, action) {
       };
     case LOGIN:
       return {
-        ...state,
         accessToken: action.payload.token,
         refreshToken: action.payload.refreshToken,
+        user: { name: action.payload.user.name, email: action.payload.user.email }
       };
     default:
       return state;

--- a/app/client/src/redux/ducks/postDuck.js
+++ b/app/client/src/redux/ducks/postDuck.js
@@ -33,7 +33,9 @@ export const getPosts = () => async (dispatch, getState) => {
   let successful = true;
 
   try {
-    const token = getState().auth.accessToken;
+    const authState = getState().auth
+    const token = authState.accessToken;
+
     if (!token) throw new Error(noTokenText);
 
     const response = await fetch(`${apiURI}/api/post`, {
@@ -61,7 +63,9 @@ export const getPosts = () => async (dispatch, getState) => {
 export const createPost = (postData) => async (dispatch, getState) => {
   let successful = true;
   try {
-    const token = getState().auth.accessToken;
+    const authState = getState().auth
+    const token = authState.accessToken;
+
     if (!token) throw new Error(noTokenText);
 
     const response = await fetch(`${apiURI}/api/post`, {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Changed addPost modal to send the community name in place of the community ID to align with the API changes in HWP-302

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [x] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
