### PR TITLE
HWP-327: Fixed JWT cookie not being set in frontend

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -1,14 +1,20 @@
 ############################################
+###       FRONTEND And BACKEND uses      ###
+############################################
+REACT_APP_API_PORT=
+REACT_APP_LOCAL_DEV=
+
+############################################
 ###             FRONTEND uses            ###
 ############################################
 REACT_APP_API_REF=
-REACT_APP_API_PORT=
-REACT_APP_LOCAL_DEV=
 
 ############################################
 ###             BACKEND uses         	 ###
 ############################################
 API_VERSION=
+FRONTEND_REF=
+FRONTEND_PORT=
 MONGO_REF=
 MONGO_PORT=
 MONGO_ROOT_USERNAME=
@@ -23,5 +29,4 @@ JWT_TOKEN_EXPIRY=
 ############################################
 ###           Docker Compose uses        ###
 ############################################
-FRONTEND_PORT=
 ENV_FILE=.env

--- a/app/server/express.js
+++ b/app/server/express.js
@@ -92,10 +92,7 @@ app.use(express.json());
 // TODO: Remove hard-coding, set env variable for openshift
 app.use(
   cors({
-    origin: [
-      "https://hwp-react-d63404-dev.apps.silver.devops.gov.bc.ca/",
-      corsOrigin,
-    ],
+    origin: corsOrigin,
     credentials: true,
   })
 );

--- a/app/server/express.js
+++ b/app/server/express.js
@@ -82,9 +82,23 @@ app.use("/api-docs", swaggerUI.serve, swaggerUI.setup(specs));
  *      bearerFormat: JWT
  */
 
+// Cors origin
+const corsOrigin = !process.env.REACT_APP_LOCAL_DEV
+  ? process.env.FRONTEND_REF
+  : `http://${process.env.FRONTEND_REF}:${process.env.FRONTEND_PORT}`;
+
 // Express middleware
 app.use(express.json());
-app.use(cors());
+// TODO: Remove hard-coding, set env variable for openshift
+app.use(
+  cors({
+    origin: [
+      "https://hwp-react-d63404-dev.apps.silver.devops.gov.bc.ca/",
+      corsOrigin,
+    ],
+    credentials: true,
+  })
+);
 app.use(cookieParser());
 app.use(
   rateLimit({

--- a/app/server/routes/v1/login.js
+++ b/app/server/routes/v1/login.js
@@ -91,19 +91,23 @@ router.post("/", async (req, res) => {
       const token = generateToken(user);
       const refreshToken = generateRefreshToken(user);
 
+      const hashedRefreshToken = await bcrypt.hash(refreshToken, 10);
+
       // Add or replace refresh token to db
       await User.updateOne(
         { user: user.name },
-        { refresh_token: refreshToken }
+        { refresh_token: hashedRefreshToken }
       );
 
       // Create JWT Refresh Cookie (HTTPOnly - JS can't touch)
       res.cookie("jwt", refreshToken, {
         httpOnly: true,
+        secure: true,
+        sameSite: "None",
       });
 
       // Send JWT
-      return res.status(201).json({ token, refreshToken });
+      return res.status(201).json({ token });
     }
     return res.status(400).send("Bad Request");
   } catch (err) {

--- a/app/server/routes/v1/token.js
+++ b/app/server/routes/v1/token.js
@@ -23,6 +23,7 @@
 require("dotenv").config();
 const express = require("express");
 const jwt = require("jsonwebtoken");
+const bcrypt = require("bcryptjs"); // hashing
 
 const router = express.Router();
 
@@ -38,6 +39,8 @@ const User = require("../../models/user.model");
  *        - Auth
  *      summary: Use refresh token to retreive a new access token.
  *      responses:
+ *        '404':
+ *          description: User not found.
  *        '401':
  *          description: Unauthorized (missing cookie).
  *        '403':
@@ -62,15 +65,31 @@ router.get("/", async (req, res) => {
     if (!(req.cookies && req.cookies.jwt)) return res.sendStatus(401);
     const refreshToken = req.cookies.jwt;
 
-    // Check refresh token exists
-    const user = await User.findOne({ refresh_token: refreshToken });
-    if (!user) return res.status(403).send("Forbidden.");
+    let username;
 
-    jwt.verify(refreshToken, process.env.JWT_REFRESH_SECRET, (err) => {
-      if (err) return res.status(403).send("Forbidden.");
-      const token = generateToken(user);
-      return res.status(200).json({ token });
-    });
+    // Verify token and get user.name from token
+    jwt.verify(
+      refreshToken,
+      process.env.JWT_REFRESH_SECRET,
+      (err, tokenUser) => {
+        if (err) return res.status(403).send("Forbidden.");
+        username = tokenUser.name;
+      }
+    );
+
+    const user = await User.findOne({ name: username });
+    if (!user) return res.status(404).send("User not found.");
+
+    // Compare refreshToken to user.refresh_token from db
+    const isRefreshTokenValid = await bcrypt.compare(
+      refreshToken,
+      user.refresh_token
+    );
+
+    if (!isRefreshTokenValid) return res.status(403).send("Forbidden.");
+
+    const token = generateToken(user);
+    return res.status(200).json({ token });
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

**DO NOT MERGE** until frontend changes have been made. These changes are SERVER-SIDE. In testing, I edited part of the client-side code to verify the cookie was being set, but have not saved those changes to this pull request.

- Updated cors options in app/server/express.js
- Hashed refreshToken before storing in database.
- Added 'secure' and 'sameSite' options to refresh token cookie.
- Updated env-template.

- app/server/express.js: cors origin field is set for local dev, and hard-coded for openshift DEV. Its set up so it should mean we just need to add the env variables into the openshift config. I have added a ticket to backlog for this to be done (HWP-328). @akroon3r 

@ZachBourque Here's what needs to happen on the frontend:
- Remove creation of 'refreshToken' cookie.
- Add `credentials: "include",` option to fetch calls that require cookie auth (login, token and logout). This means the login fetch call in authDuck.js and if token refreshing uses a seperate fetch call, it also requires this option.
- Refresh the token with /token endpoint. The request does NOT require an authorization header, body, or parameters. As stated above, it does require `credentials: "include",`.

## Requires

Add 'Requires Attention' label if appropriate.

- [x] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [x] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

May require removing of the frontend image in Docker Desktop to see changes to frontend.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

- Tested login on frontend and using developer tools in browser to check the 'jwt' cookie was set.
- Tested login, token, and logout in swagger docs.
- Tested ternary operator for 'corsOrigin' in app/server/express.js when REACT_APP_LOCAL_DEV is not set (as it would be in OpenShift).

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [x] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [x] If attention is required by the developer such as updating the .env file, these requirements have been listed.
