### PR TITLE
HWP-307 Frontend Refresh Token storage

### DIFF
--- a/app/client/src/layout/sideMenu.js
+++ b/app/client/src/layout/sideMenu.js
@@ -19,7 +19,8 @@
  * @author [Jayna Bettesworth](bettesworthjayna@gmail.com)
  * @module
  */
-
+import { connect } from "react-redux";
+import { logout } from "../redux/ducks/authDuck";
 import React from "react";
 import { Link } from "react-router-dom";
 import "./sideMenu.css";
@@ -28,14 +29,9 @@ import House from "@mui/icons-material/House";
 import Person from "@mui/icons-material/Person";
 import HelpCenter from "@mui/icons-material/HelpCenter";
 import LogOut from "@mui/icons-material/Logout";
-//import DarkMode from '@mui/icons-material/DarkMode'
 import Group from "@mui/icons-material/Group";
 
-//import {logOff} from '../components/logout';
-
-// props: {darkMode, setDarkMode}
-// <li onClick={updateDarkMode} id='DMode'><DarkMode />  Dark Mode</li>
-const SideMenu = () => {
+const SideMenu = (props) => {
   async function openSlideMenu() {
     document.getElementById("menu").style.width = "250px";
     document.getElementById("menu").style.marginLeft = "250px";
@@ -46,26 +42,9 @@ const SideMenu = () => {
     document.getElementById("menu").style.marginLeft = "0px";
   }
 
-  /*
-  async function updateDarkMode(event){
-    event.preventDefault()
-    setDarkMode(!darkMode)
-    const req = await fetch(`${window._env_.REACT_APP_API_REF}/editprofile`, {
-       method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'x-access-token': localStorage.getItem('token'),
-        },
-        body: JSON.stringify({
-            darkMode: darkMode,
-        }),
-    })
-  }
-  */
-
   // Logout
   async function logOff() {
-    fetch(`${window._env_.REACT_APP_API_REF}/logout`, {});
+    props.logout();
   }
 
   return (
@@ -117,4 +96,8 @@ const SideMenu = () => {
   );
 };
 
-export default SideMenu;
+const mapStateToProps = (state) => ({});
+
+const mapDispatchToProps = { logout };
+
+export default connect(mapStateToProps, mapDispatchToProps)(SideMenu);


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added logout to authDuck.js
- Modified sideMenu.js to call logout action
- Added credentials: "include" to login and logout redux actions

## Notes

This PR stores the refresh token as an httpOnly cookie, currently said cookie is not being used to create a new access token. That will be done when the custom axios instance is implemented.

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [x] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
