### PR TITLE
Fix api crash on res.sendStatus

### DIFF
--- a/app/server/routes/v1/comment/comment.js
+++ b/app/server/routes/v1/comment/comment.js
@@ -254,7 +254,7 @@ router.patch("/:id", async (req, res) => {
 
     await Comment.updateOne({ _id: req.params.id }, query).exec();
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }

--- a/app/server/routes/v1/community/community.js
+++ b/app/server/routes/v1/community/community.js
@@ -275,7 +275,7 @@ router.patch("/:title", async (req, res) => {
 
     await Community.updateOne({ title: community.title }, query).exec();
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }

--- a/app/server/routes/v1/community/communityFlags.js
+++ b/app/server/routes/v1/community/communityFlags.js
@@ -154,7 +154,7 @@ router.post("/:title", async (req, res) => {
       );
     }
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }
@@ -226,7 +226,7 @@ router.delete("/:title", async (req, res) => {
       { $pull: { "flags.$.flaggedBy": user.id } }
     );
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }

--- a/app/server/routes/v1/community/communityMembers.js
+++ b/app/server/routes/v1/community/communityMembers.js
@@ -129,7 +129,7 @@ router.patch("/join/:title", async (req, res) => {
       }
     );
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }
@@ -187,7 +187,7 @@ router.delete("/leave/:title", async (req, res) => {
       }
     );
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }

--- a/app/server/routes/v1/community/communityRules.js
+++ b/app/server/routes/v1/community/communityRules.js
@@ -84,7 +84,7 @@ router.put("/:title", async (req, res) => {
       { $set: { rules: req.body.rules } }
     ).exec();
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }

--- a/app/server/routes/v1/community/communityTags.js
+++ b/app/server/routes/v1/community/communityTags.js
@@ -138,7 +138,7 @@ router.post("/:title", async (req, res) => {
       { $push: { tags: { tag: req.query.tag, count: 0 } } }
     );
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }
@@ -205,7 +205,7 @@ router.delete("/:title", async (req, res) => {
       { $pull: { tags: { tag: req.query.tag } } }
     );
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }

--- a/app/server/routes/v1/logout.js
+++ b/app/server/routes/v1/logout.js
@@ -77,7 +77,7 @@ router.get("/", async (req, res) => {
 
     await User.updateOne({ name: user.name }, { refresh_token: "" });
     res.clearCookie("jwt", { httpOnly: true, secure: true, sameSite: "None" });
-    res.sendStatus(204);
+    res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }

--- a/app/server/routes/v1/post/post.js
+++ b/app/server/routes/v1/post/post.js
@@ -358,7 +358,7 @@ router.patch("/:id", async (req, res) => {
 
     await Post.updateOne({ _id: req.params.id }, query).exec();
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }

--- a/app/server/routes/v1/post/postFlags.js
+++ b/app/server/routes/v1/post/postFlags.js
@@ -151,7 +151,7 @@ router.post("/:id", async (req, res) => {
       );
     }
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }

--- a/app/server/routes/v1/post/postTags.js
+++ b/app/server/routes/v1/post/postTags.js
@@ -156,7 +156,7 @@ router.post("/:id", async (req, res) => {
       { $inc: { "tags.$.count": 1 } }
     );
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }
@@ -242,7 +242,7 @@ router.delete("/:id", async (req, res) => {
       { $inc: { "tags.$.count": -1 } }
     );
 
-    return res.sendStatus(204);
+    return res.status(204).send("");
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
   }

--- a/app/server/routes/v1/token.js
+++ b/app/server/routes/v1/token.js
@@ -62,7 +62,8 @@ const User = require("../../models/user.model");
 router.get("/", async (req, res) => {
   try {
     // Get refresh token from cookies
-    if (!(req.cookies && req.cookies.jwt)) return res.sendStatus(401);
+    if (!(req.cookies && req.cookies.jwt))
+      return res.status(401).send("Missing cookie.");
     const refreshToken = req.cookies.jwt;
 
     let username;

--- a/app/server/routes/v1/user.js
+++ b/app/server/routes/v1/user.js
@@ -155,11 +155,11 @@ router.patch("/", async (req, res) => {
 
     return res.status(204).send("");
   } catch (err) {
-    return res
-      .status(400)
-      .send(
-        `Bad Request. The User in the params of the Request is either missing or malformed. ${err}`
-      );
+    // Error wasn't explicitly thrown
+    if (!err.statusCode) {
+    } else {
+      return res.status(err.statusCode).send(err.response);
+    }
   }
 });
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Issue: https://exerror.com/error-err_http_headers_sent-cannot-set-headers-after-they-are-sent-to-the-client/#h-how-to-solve-error-err_http_headers_sent-cannot-set-headers-after-they-are-sent-to-the-client
- Changed `res.sendStatus();` to `res.status().send('');`

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
