### PR TITLE
Post Modal only lists community the user is a part of

### DIFF
--- a/app/client/src/components/modals/addPostModal.js
+++ b/app/client/src/components/modals/addPostModal.js
@@ -52,12 +52,12 @@ const CreatePost = (props) => {
       community: community,
     };
 
-    const successful = await props.createPost(post)
+    const successful = await props.createPost(post);
     if (successful === true) {
-      setTitle("")
-      setMessage("")
-      setCommunity("")
-      props.onClose()
+      setTitle("");
+      setMessage("");
+      setCommunity("");
+      props.onClose();
     }
   };
 
@@ -102,7 +102,12 @@ const CreatePost = (props) => {
             {props.communities.map((comm) => (
               <div key={comm._id}>
                 {/* TODO: change button input for choosing community to radio  */}
-                <Button onClick={() => onCommunityClick(comm.title)} variant={`${comm.title === community ? 'contained' : 'outlined'}`}>
+                <Button
+                  onClick={() => onCommunityClick(comm.title)}
+                  variant={`${
+                    comm.title === community ? "contained" : "outlined"
+                  }`}
+                >
                   {comm.title}{" "}
                 </Button>
               </div>
@@ -124,8 +129,8 @@ CreatePost.propTypes = {
 };
 
 const mapStateToProps = (state) => ({
-  communities: state.communities.items,
-  auth: state.auth
+  communities: state.communities.usersCommunities,
+  auth: state.auth,
 });
 
 export default connect(mapStateToProps, { getCommunities, createPost })(


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Changed postModal.js to use the usersCommunities array from the redux store as opposed to the all communities array

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [x] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
