### PR TITLE
HWP-306: Order communities by engagement option

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -26,6 +26,11 @@ JWT_SECRET=
 JWT_REFRESH_SECRET=
 JWT_TOKEN_EXPIRY=
 
+## Community Engagement - How actions are weighted to determine engagement in a community
+COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_COMMUNITY=
+COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_POST=
+COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_COMMENT=
+
 ############################################
 ###           Docker Compose uses        ###
 ############################################

--- a/app/server/models/user.model.js
+++ b/app/server/models/user.model.js
@@ -65,7 +65,13 @@
  *          type: array
  *          description: Communities User has joined.
  *          items:
- *            - $ref: '#/components/schemas/Community/properties/title'
+ *            type: object
+ *            properties:
+ *              community:
+ *                $ref: '#/components/schemas/Community/properties/title'
+ *              engagement:
+ *                type: number
+ *                description: Engagement in the community based on posts, comments, votes.
  *      required:
  *        - username
  *        - email
@@ -86,7 +92,7 @@ const User = new mongoose.Schema(
     title: { type: String },
     bio: { type: String },
     registeredOn: { type: String, required: true },
-    communities: [{ type: String }],
+    communities: [{ community: String, engagement: Number }],
   },
   { collection: "user" }
 );

--- a/app/server/routes/v1/comment/comment.js
+++ b/app/server/routes/v1/comment/comment.js
@@ -71,7 +71,12 @@ router.post("/", async (req, res) => {
     if (!user) return res.status(404).send("User not found.");
     if (!post) return res.status(404).send("Post not found.");
 
-    if (!user.communities.includes(post.community))
+    if (
+      !(await User.exists({
+        _id: user.id,
+        "communities.community": post.community,
+      }))
+    )
       return res
         .status(403)
         .send("Must be a part of community to comment in community.");

--- a/app/server/routes/v1/comment/comment.js
+++ b/app/server/routes/v1/comment/comment.js
@@ -92,6 +92,20 @@ router.post("/", async (req, res) => {
       createdOn: moment().format("MMMM Do YYYY, h:mm:ss a"),
     });
 
+    // Update user engagement
+    await User.updateOne(
+      {
+        _id: user.id,
+        communities: { $elemMatch: { community: post.community } },
+      },
+      {
+        $inc: {
+          "communities.$.engagement":
+            process.env.COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_COMMENT,
+        },
+      }
+    ).exec();
+
     return res.status(201).json(comment);
   } catch (err) {
     return res.status(400).send(`Bad Request: ${err}`);
@@ -337,6 +351,20 @@ router.delete("/:id", async (req, res) => {
 
     // Remove comment
     await Comment.deleteOne({ _id: comment.id }).exec();
+
+    // Update user engagement
+    await User.updateOne(
+      {
+        _id: user.id,
+        communities: { $elemMatch: { community: comment.community } },
+      },
+      {
+        $inc: {
+          "communities.$.engagement":
+            -process.env.COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_COMMENT,
+        },
+      }
+    ).exec();
 
     return res.status(204).send("Comment removed.");
   } catch (err) {

--- a/app/server/routes/v1/comment/commentReply.js
+++ b/app/server/routes/v1/comment/commentReply.js
@@ -118,7 +118,12 @@ router.post("/:id", async (req, res) => {
     if (!!comment.replyTo)
       return res.status(403).send("Not allowed to reply to a reply.");
 
-    if (!user.communities.includes(comment.community))
+    if (
+      !(await User.exists({
+        _id: user.id,
+        "communities.community": comment.community,
+      }))
+    )
       return res
         .status(403)
         .send("Must be a part of community to comment in community.");

--- a/app/server/routes/v1/community/community.js
+++ b/app/server/routes/v1/community/community.js
@@ -92,13 +92,18 @@ router.post("/", async (req, res) => {
       { username: user.username },
       {
         $push: {
-          communities: community.title,
+          communities: {
+            community: community.title,
+            engagement:
+              process.env.COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_COMMUNITY || 0,
+          },
         },
       }
     );
 
     return res.status(201).json(community);
   } catch (err) {
+    console.log(err);
     return res
       .status(400)
       .send(
@@ -118,13 +123,13 @@ router.post("/", async (req, res) => {
  *      tags:
  *        - Community
  *      summary: Get all communities or only communities user is a part of.
- *      description: Use optional query 'user=true' to get only communities user is a part of.
+ *      description: Use optional query 'orderBy' with<br>'lastJoined' - Communities user has joined, in the order of last joined first.<br>'engagement' - Communities user has joined, in the order of most engagement.
  *      parameters:
  *        - in: query
  *          required: false
- *          name: user
+ *          name: orderBy
  *          schema:
- *            type: boolean
+ *            type: string
  *      responses:
  *        '404':
  *          description: User not found. **||** <br>Communities not found.
@@ -146,11 +151,47 @@ router.get("/", async (req, res) => {
 
     let communities;
 
-    if (req.query.user === "true") {
+    if (req.query.orderBy === "lastJoined") {
       // Ordered by last joined
       communities = await Community.find({ members: user.id }, "", {
         sort: { _id: -1 },
       }).exec();
+    } else if (req.query.orderBy === "engagement") {
+      // Order by engagment (posts, comments, votes)
+      communities = await Community.aggregate([
+        {
+          $lookup: {
+            from: "user",
+            let: { community_title: "$title" },
+            pipeline: [
+              {
+                $unwind: "$communities",
+              },
+              {
+                $match: {
+                  $expr: {
+                    $and: [
+                      { $eq: ["$communities.community", "$$community_title"] },
+                    ],
+                  },
+                },
+              },
+            ],
+            as: "userData",
+          },
+        },
+        {
+          $addFields: {
+            engagement: {
+              $ifNull: [{ $sum: ["$userData.communities.engagement"] }, 0],
+            },
+          },
+        },
+        {
+          $project: { userData: 0 },
+        },
+        { $sort: { engagement: -1, _id: -1 } },
+      ]).exec();
     } else {
       // Ordered by first created
       communities = await Community.find({}, "", { sort: { _id: 1 } }).exec();
@@ -346,8 +387,8 @@ router.delete("/:title", async (req, res) => {
 
     // Remove reference to community from users
     await User.updateMany(
-      { communities: community.title },
-      { $pull: { communities: community.title } }
+      { "communities.community": community.title },
+      { $pull: { "communities.community": community.title } }
     ).exec();
 
     // Remove posts from community

--- a/app/server/routes/v1/community/communityMembers.js
+++ b/app/server/routes/v1/community/communityMembers.js
@@ -124,7 +124,7 @@ router.patch("/join/:title", async (req, res) => {
       { username: user.username },
       {
         $push: {
-          communities: community.title,
+          communities: { community: community.title, engagement: 0 },
         },
       }
     );
@@ -182,7 +182,7 @@ router.delete("/leave/:title", async (req, res) => {
       { username: user.username },
       {
         $pull: {
-          communities: community.title,
+          "communities.community": community.title,
         },
       }
     );

--- a/app/server/routes/v1/post/post.js
+++ b/app/server/routes/v1/post/post.js
@@ -107,7 +107,12 @@ router.post("/", async (req, res) => {
         _id: user.id,
         communities: { $elemMatch: { community: req.body.community } },
       },
-      { $inc: { "communities.$.engagement": 1 } }
+      {
+        $inc: {
+          "communities.$.engagement":
+            process.env.COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_POST,
+        },
+      }
     ).exec();
 
     return res.status(201).json(post);
@@ -433,6 +438,20 @@ router.delete("/:id", async (req, res) => {
     await Post.deleteOne({
       _id: post.id,
     }).exec();
+
+    // Update user engagement
+    await User.updateOne(
+      {
+        _id: user.id,
+        communities: { $elemMatch: { community: post.community } },
+      },
+      {
+        $inc: {
+          "communities.$.engagement":
+            -process.env.COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_POST,
+        },
+      }
+    ).exec();
 
     return res.status(204).send("Post removed.");
   } catch (err) {

--- a/app/server/routes/v1/post/post.js
+++ b/app/server/routes/v1/post/post.js
@@ -74,7 +74,12 @@ router.post("/", async (req, res) => {
     if (!user) return res.status(404).send("User not found.");
     if (!community) return res.status(404).send("Community not found.");
 
-    if (!user.communities.includes(community.title))
+    if (
+      !(await User.exists({
+        _id: user.id,
+        "communities.community": community.title,
+      }))
+    )
       return res
         .status(403)
         .send("Must be a part of community to post in community.");
@@ -95,6 +100,15 @@ router.post("/", async (req, res) => {
       pinned: req.body.pinned || false,
       createdOn: moment().format("MMMM Do YYYY, h:mm:ss a"),
     });
+
+    // Update user engagement
+    await User.updateOne(
+      {
+        _id: user.id,
+        communities: { $elemMatch: { community: req.body.community } },
+      },
+      { $inc: { "communities.$.engagement": 1 } }
+    ).exec();
 
     return res.status(201).json(post);
   } catch (err) {

--- a/app/server/routes/v1/register.js
+++ b/app/server/routes/v1/register.js
@@ -91,13 +91,14 @@ router.post("/", async (req, res) => {
       { username: req.body.username },
       {
         $push: {
-          communities: "Welcome",
+          communities: { community: "Welcome", engagement: 0 },
         },
       }
     );
 
     return res.status(201).send("Registered.");
   } catch (err) {
+    console.log(err);
     return res.status(400).send(`Bad Request: ${err}`);
   }
 });

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,6 +53,10 @@ services:
       dockerfile: ./app/server/Dockerfile
       args:
         env: ${ENV_FILE:-.env-template}
+    environment:
+      - COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_COMMUNITY=${COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_COMMUNITY:-0}
+      - COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_POST=${COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_POST:-5}
+      - COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_COMMENT=${COMMUNITY_ENGAGEMENT_WEIGHT_CREATE_COMMENT:-1}
     networks:
       - hwp-network
     ports:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- When using GET /api/community, you can specify the optional query parameter "orderBy" equal to "engagement" and communities that are returned will be ordered by your engagement in the community.
- Engagement ratings can be increased by creating the community, creating a post, or creating a comment.
- Engagement ratings can decrease by removing posts, or comments.
- The weight of each action is currently: create_community=0, create_post=5, create_comment=1
- We can use this engagement rating anywhere we want in the community. We can make voting have an engagement value, etc.

## Requires

Add 'Requires Attention' label if appropriate.

- [x] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [x] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

@ZachBourque in GET /api/community, user=true was changed to orderBy=lastJoined

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested the engagement features in swagger.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [x] Tested by Brady.

## Does the change impact or break the Docker build?

- [x] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [x] Yes
- [ ] No
Added env variable defaults to API in docker-compose

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [x] If attention is required by the developer such as updating the .env file, these requirements have been listed.
