### PR TITLE
HWP-405 Community page only display posts in that community

### DIFF
--- a/app/client/src/components/PostsList.jsx
+++ b/app/client/src/components/PostsList.jsx
@@ -20,24 +20,19 @@
  * @module
  */
 
-import React, { useEffect } from "react";
+import React from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 
-import { getPosts } from "../redux/ducks/postDuck";
 import Post from "./Post";
 import FlagPostModal from "./modals/FlagPostModal";
 import DeletePostModal from "./modals/DeletePostModal";
 import EditPostModal from "./modals/EditPostModal";
 
 const PostsList = (props) => {
-  useEffect(() => {
-    props.getPosts();
-  }, []);
-
   return (
     <div>
-      {props.posts.map((post) => (
+      {props.posts?.map((post) => (
         <Post post={post} key={post._id} />
       ))}
       <FlagPostModal />
@@ -48,12 +43,9 @@ const PostsList = (props) => {
 };
 
 PostsList.propTypes = {
-  getPosts: PropTypes.func.isRequired,
   posts: PropTypes.array.isRequired,
 };
 
-const mapStateToProps = (state) => ({
-  posts: state.posts.items,
-});
+const mapStateToProps = (state) => ({});
 
-export default connect(mapStateToProps, { getPosts })(PostsList);
+export default connect(mapStateToProps, {})(PostsList);

--- a/app/client/src/views/CommunityPage.jsx
+++ b/app/client/src/views/CommunityPage.jsx
@@ -31,7 +31,7 @@ import Typography from "@mui/material/Typography";
 import { connect } from "react-redux";
 import { useParams } from "react-router-dom";
 import PropTypes from "prop-types";
-import Posts from "../components/PostsList";
+import PostsList from "../components/PostsList";
 import PostModal from "../components/modals/AddPostModal";
 import { getCommunityPosts, getCommunity } from "../redux/ducks/communityDuck";
 
@@ -61,7 +61,7 @@ const CommunityPage = (props) => {
               }}
             >
               <Typography variant="h6" component="h5">
-                Posts {console.log(props.community)}
+                Posts
               </Typography>
               <Button onClick={() => setShow(true)}> Add Post </Button>
 
@@ -71,7 +71,7 @@ const CommunityPage = (props) => {
                 show={show}
               />
             </Box>
-            <Posts />
+            <PostsList posts={props.community.posts} />
           </Paper>
         </Grid>
         <Grid item xs={4}>

--- a/app/client/src/views/HomePage.jsx
+++ b/app/client/src/views/HomePage.jsx
@@ -20,22 +20,25 @@
  * @module
  */
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import Grid from "@mui/material/Grid";
 import Paper from "@mui/material/Paper";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
-
+import { getPosts } from "../redux/ducks/postDuck";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import UsersCommunitiesList from "../components/UsersCommunitiesList";
-import Posts from "../components/PostsList";
+import PostsList from "../components/PostsList";
 import PostModal from "../components/modals/AddPostModal";
 import AddCommunityModal from "../components/modals/AddCommunityModal";
 
 const HomePage = (props) => {
+  useEffect(() => {
+    props.getPosts();
+  }, []);
   const [show, setShow] = useState(false);
 
   const [createCommunityOpen, setCreateCommunityOpen] = useState(false);
@@ -71,7 +74,7 @@ const HomePage = (props) => {
 
               <PostModal onClose={() => setShow(false)} show={show} />
             </Box>
-            <Posts />
+            <PostsList posts={props.posts} />
           </Paper>
         </Grid>
         <Grid item xs={4}>
@@ -122,6 +125,7 @@ HomePage.propTypes = {
 const mapStateToProps = (state) => ({
   communities: state.communities.items,
   auth: state.auth.accessToken,
+  posts: state.posts.items,
 });
 
-export default connect(mapStateToProps, {})(HomePage);
+export default connect(mapStateToProps, { getPosts })(HomePage);

--- a/app/client/src/views/PostsPage.jsx
+++ b/app/client/src/views/PostsPage.jsx
@@ -20,18 +20,23 @@
  * @module
  */
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import PostsList from "../components/PostsList";
+import { getPosts } from "../redux/ducks/postDuck";
 import AddPostModal from "../components/modals/AddPostModal";
+import { connect } from "react-redux";
 
-const PostsPage = () => {
+const PostsPage = (props) => {
   const [show, setShow] = useState(false);
+  useEffect(() => {
+    props.getPosts();
+  }, []);
 
   return (
     <div>
       <h1>Posts</h1>
-      <PostsList />
+      <PostsList posts={props.posts} />
       <br />
       <button onClick={() => setShow(true)}>Add Post</button>
       <AddPostModal onClose={() => setShow(false)} show={show} />
@@ -39,4 +44,12 @@ const PostsPage = () => {
   );
 };
 
-export default PostsPage;
+const mapStateToProps = (state) => ({
+  posts: state.posts.items,
+});
+
+const mapActionsToProps = {
+  getPosts,
+};
+
+export default connect(mapStateToProps, mapActionsToProps)(PostsPage);


### PR DESCRIPTION
# Description

This PR fixes an issue in CommunitiesPage.jsx where said page was displaying all posts, not just posts specific to that community.

This PR includes the following proposed change(s):

- Modified PostsList.jsx to take in a posts array as props
- Modified all instances of PostsList to pass in a posts array as props

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [x] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
