### PR TITLE
HWP-407: Bug fixed in comment.js route checkPatchQuery() parameters

### DIFF
--- a/app/server/routes/v1/comment/comment.js
+++ b/app/server/routes/v1/comment/comment.js
@@ -304,7 +304,7 @@ router.patch("/:id", async (req, res) => {
       throw new ResponseError(403, "Missing message in body of the request.");
 
     req.log.addAction("Checking edit query.");
-    const query = checkPatchQuery(req.body, documents.community, [
+    const query = checkPatchQuery(req.body, documents.comment, [
       "creator",
       "post",
       "community",


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Because of the logger, I was able to find this bug in seconds. The checkPatchQuery function was being called with a parameter of documents.community when it should have been documents.comment

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
