### PR TITLE
HWP-408: Fixed renaming community not updating posts

### DIFF
--- a/app/server/routes/v1/community/community.js
+++ b/app/server/routes/v1/community/community.js
@@ -391,6 +391,13 @@ router.patch("/:title", async (req, res) => {
     ).exec();
     req.log.addAction("Community updated.");
 
+    req.log.addAction("Updating posts in community.");
+    await Post.updateMany(
+      { community: documents.community.title },
+      { $set: { community: req.body.title } }
+    ).exec();
+    req.log.addAction("Community posts updated.");
+
     req.log.setResponse(204, "Success", null);
     return res.status(204).send("Success. No content to return.");
   } catch (err) {


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Renaming a community didn't update the posts within the community to use the new community title.

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Edited a community title in swagger and verified the posts stayed within the community.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
