### PR TITLE
Adjusts community tile sizing

### DIFF
--- a/app/client/src/views/ProfilePage.jsx
+++ b/app/client/src/views/ProfilePage.jsx
@@ -99,19 +99,23 @@ const ProfilePage = (props) => {
           <Grid
             container
             direction="column"
-            alignitems="flex-start"
+            alignItems="flex-start"
             justifyContent="space-evenly"
           >
             <Grid item xs={12}>
               <Avatar
-                sx={{ width: 150, height: 150 }}
+                sx={{ width: 150, height: 150, mb: 1 }}
                 src="https://source.unsplash.com/random/150×150/?profile%20picture"
               />
-              <br />
-              <Grid item xs={12}>
+              <Grid
+                item
+                xs={12}
+                sx={{
+                  mb: 1,
+                }}
+              >
                 <ProfileInfo username={username} />
               </Grid>
-              <br />
               <Grid item xs={12}>
                 <Box
                   sx={{
@@ -120,7 +124,7 @@ const ProfilePage = (props) => {
                 >
                   <Typography
                     variant="h6"
-                    style={{ fontWeight: 600, color: "#313132" }}
+                    sx={{ fontWeight: 600, color: "primary.main" }}
                   >
                     Interests
                   </Typography>
@@ -145,10 +149,9 @@ const ProfilePage = (props) => {
         <Grid item xs={3}>
           <Grid container direction="row" justifyContent="space-evenly">
             <Grid item xs={12}>
-              <Typography variant="h4" style={{ fontWeight: 600 }}>
+              <Typography variant="h4" sx={{ fontWeight: 600, mb: 1 }}>
                 Bio
               </Typography>
-              <br />
               <Typography variant="body1">
                 {props.profile.bio || "No bio to display"}
               </Typography>
@@ -159,10 +162,9 @@ const ProfilePage = (props) => {
         <Grid item xs={4}>
           <Grid container direction="row" justifyContent="space-evenly">
             <Grid item xs={12}>
-              <Typography variant="h4" style={{ fontWeight: 600 }}>
+              <Typography variant="h4" sx={{ fontWeight: 600, mb: 1 }}>
                 Your Communities
               </Typography>
-              <br />
               <Grid container spacing={2}>
                 {props.communities.slice(0, 4).map((element) => (
                   <Grid item xs={6} key={element._id}>
@@ -171,23 +173,23 @@ const ProfilePage = (props) => {
                         backgroundColor: "#FFF",
                         boxShadow: 1,
                         borderRadius: "10px",
-                        color: "#313132",
-                        py: 1,
-                        px: 2,
+                        color: "primary.main",
+                        py: 2,
+                        px: 3,
                         textAlign: "start",
                         height: "auto",
                       }}
                     >
-                      <Typography variant="h6" style={{ fontWeight: 600 }}>
+                      <Typography variant="h6" sx={{ fontWeight: 600 }}>
                         {element.title}
                       </Typography>
                       <Stack direction="row" spacing={1}>
                         <GroupsIcon fontSize="small" />
                         <Typography
                           variant="p"
-                          style={{
+                          sx={{
                             color: "#999",
-                            paddingLeft: "0.5em",
+                            pl: "0.5em",
                           }}
                         >
                           {element.memberCount || 0}
@@ -196,14 +198,14 @@ const ProfilePage = (props) => {
                       <Stack sx={{ mt: "5px" }}>
                         <Typography
                           variant="p"
-                          style={{ fontWeight: 600, color: "#313132" }}
+                          sx={{ fontWeight: 600, color: "primary.main" }}
                         >
                           Latest Activity:
                         </Typography>
                         <Typography
                           variant="p"
-                          style={{
-                            color: "#999",
+                          sx={{
+                            color: "neutral.main.dark",
                             textAlign: "left",
                           }}
                         >
@@ -218,13 +220,12 @@ const ProfilePage = (props) => {
           </Grid>
         </Grid>
         <Grid item xs={2}>
-          <Typography variant="h4" style={{ fontWeight: 600 }}>
+          <Typography variant="h4" sx={{ fontWeight: 600, mb: 1 }}>
             Settings
           </Typography>
-          <br />
           <Box
             sx={{
-              color: "#313132",
+              color: "neutral.main",
               boxShadow: 2,
               py: 1,
               px: 2,
@@ -233,7 +234,7 @@ const ProfilePage = (props) => {
           >
             <FormControl>
               <FormLabel id="notification-frequency-radios-label">
-                <Typography variant="h6" style={{ fontWeight: 600 }}>
+                <Typography variant="h6" sx={{ fontWeight: 600 }}>
                   Notifications
                 </Typography>
               </FormLabel>
@@ -273,21 +274,28 @@ const ProfilePage = (props) => {
               </RadioGroup>
             </FormControl>
             <Divider />
-            <br />
-            <Stack direction="row" spacing={1}>
-              <Typography variant="p" style={{ fontWeight: 600 }}>
-                Dark Mode
-              </Typography>
-              <Switch />
-            </Stack>
+            <Box
+              sx={{
+                mt: 1,
+              }}
+            >
+              <Stack direction="row" spacing={1}>
+                <Typography
+                  variant="p"
+                  sx={{ fontWeight: 600, alignSelf: "center" }}
+                >
+                  Dark Mode
+                </Typography>
+                <Switch />
+              </Stack>
+            </Box>
           </Box>
         </Grid>
 
-        <Grid item xs={8}>
-          <Typography variant="h4" style={{ fontWeight: 600 }}>
+        <Grid item xs={8} sx={{}}>
+          <Typography variant="h4" sx={{ fontWeight: 600, mb: 1 }}>
             Recent Posts
           </Typography>
-          <br />
           <Stack direction="row" spacing={2}>
             {props.communities.slice(0, 4).map((element) => (
               <Box
@@ -302,7 +310,7 @@ const ProfilePage = (props) => {
               >
                 <Box
                   sx={{
-                    backgroundColor: "#003366",
+                    backgroundColor: "primary.main",
                     width: "600px",
                     py: 1,
                     px: 2,
@@ -311,13 +319,13 @@ const ProfilePage = (props) => {
                 >
                   <Typography
                     variant="h5"
-                    style={{ fontWeight: 600, color: "#FFF" }}
+                    sx={{ fontWeight: 600, color: "#FFF" }}
                   >
                     {element.title}
                   </Typography>
                   <Typography
                     variant="caption"
-                    style={{ fontWeight: 600, color: "#FFF" }}
+                    sx={{ fontWeight: 600, color: "#FFF" }}
                   >
                     by {element.creatorName}
                   </Typography>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Adjusts padding of 'Your Communities' tiles
- Replaces use of 'style' with 'sx' on the profile page
- Removes \<br \/\> elements and uses margin to space elements on profile page

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

No tests needed. Visual changes and minor refactoring only.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
