### PR TITLE
HWP-415: Fixed comment edit showing wrong date

### DIFF
--- a/app/client/src/components/Comment.jsx
+++ b/app/client/src/components/Comment.jsx
@@ -41,12 +41,12 @@ export const Comment = (props) => {
     ? props.comment.edits[0].timeStamp || ""
     : "";
   let editDate =
-    moment(moment.utc(editTimeStamp.split(",")[0], "MMMM Do YYYY").toDate())
+    moment(moment.utc(editTimeStamp, "MMMM Do YYYY, h:mm:ss a").toDate())
       .local()
       .format("MMMM Do YYYY") || "";
 
-  if (editDate === today) editDate = `Today`;
-  if (editDate === yesterday) editDate = `Yesterday`;
+  if (editDate.split(",")[0] === today) editDate = `Today`;
+  if (editDate.split(",")[0] === yesterday) editDate = `Yesterday`;
 
   // Convert to local time
   let createdOn =
@@ -56,15 +56,15 @@ export const Comment = (props) => {
       .local()
       .format("MMMM Do YYYY, h:mm:ss a") || "";
   // Remove milliseconds
-  createdOn = `${createdOn.substr(0, createdOn.length - 6)} ${createdOn.substr(
-    createdOn.length - 2,
-    createdOn.length
-  )}`;
+  createdOn = `${createdOn.substring(
+    0,
+    createdOn.length - 6
+  )} ${createdOn.substring(createdOn.length - 2, createdOn.length)}`;
   const splitCreatedOn = createdOn.split(",");
 
-  if (splitCreatedOn[0] === today) createdOn = `Today${splitCreatedOn[1]}`;
+  if (splitCreatedOn[0] === today) createdOn = `Today,${splitCreatedOn[1]}`;
   if (splitCreatedOn[0] === yesterday)
-    createdOn = `Yesterday${splitCreatedOn[1]}`;
+    createdOn = `Yesterday,${splitCreatedOn[1]}`;
 
   return (
     <Card style={{ margin: 10 }}>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Comment edit was showing the wrong date.
- Converted `substr` to `substring`, as `substr` is depricated and may have its support dropped at some point in the future.

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested in frontend after making an edit to a comment.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
