### PR TITLE
HWP-422: Fixed creatorName not being set on comment reply

### DIFF
--- a/app/server/routes/v1/comment/commentReply.js
+++ b/app/server/routes/v1/comment/commentReply.js
@@ -186,11 +186,22 @@ router.post("/:id", async (req, res) => {
     ).exec();
     req.log.addAction("hasReplies updated.");
 
+    req.log.addAction("Getting creator name.");
+    const { firstName, lastName } = documents.user;
+    let creatorName;
+
+    if (firstName && firstName !== "") {
+      // If lastName, set full name, else just firstName
+      creatorName =
+        lastName && lastName !== "" ? `${firstName} ${lastName}` : firstName;
+    }
+
     // Create reply
     req.log.addAction("Creating reply.");
     const reply = await Comment.create({
       message: req.body.message,
       creator: documents.user.id,
+      creatorName: creatorName || documents.user.username,
       post: documents.comment.post,
       community: documents.comment.community,
       createdOn: moment().format("MMMM Do YYYY, h:mm:ss a"),


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- creatorName wasn't being set on comment replies.

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Replied to a comment on frontend application.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
