### PR TITLE
HWP- : LoadingButton Component Override

### DIFF
--- a/app/client/src/App.jsx
+++ b/app/client/src/App.jsx
@@ -38,6 +38,17 @@ import AlertList from "./components/AlertList";
 
 function App() {
   const theme = createTheme({
+    components: {
+      MuiLoadingButton: {
+        styleOverrides: {
+          disabledProp: ({ ownerState, theme }) => ({
+            ...(ownerState.disabled === true && {
+              backgroundColor: theme.palette.neutral[200] || "grey",
+            }),
+          }),
+        },
+      },
+    },
     palette: {
       mode: "light",
       primary: {

--- a/app/client/src/views/CommunitiesPage.jsx
+++ b/app/client/src/views/CommunitiesPage.jsx
@@ -95,16 +95,17 @@ const CommunitiesPage = () => {
           <Box
             mb="15px"
             sx={{
-              backgroundColor: "#036",
+              backgroundColor: "primary.main",
               borderRadius: "10px",
               color: "white",
               px: 1,
-              py: 0.5,
+              py: 0.8,
               textAlign: "center",
             }}
           >
             <Typography
               variant="h6"
+              component="h5"
               sx={{
                 fontWeight: 600,
               }}

--- a/app/client/src/views/HomePage.jsx
+++ b/app/client/src/views/HomePage.jsx
@@ -31,6 +31,7 @@ import PostsList from "../components/PostsList";
 import PostModal from "../components/modals/AddPostModal";
 import AddCommunityModal from "../components/modals/AddCommunityModal";
 import AddIcon from "@mui/icons-material/Add";
+import { LoadingButton } from "@mui/lab";
 
 const HomePage = (props) => {
   useEffect(() => {
@@ -109,6 +110,7 @@ const HomePage = (props) => {
                   sx={{
                     fontWeight: 600,
                     pl: "5.25em",
+                    pt: 0.3,
                   }}
                 >
                   My Communities


### PR DESCRIPTION
# Description

Makes some minor style changes to the homepage and communities page right-side banner vertical padding and adds custom styling to mui LoadingButton components that are using the 'disabled' property.

This PR includes the following proposed change(s):

- Increases padding of communities page right-side header banner so that it matches the homepage
- Centres the text of the right-side header banner on the homepage
- Adds a custom css rule for disabled mui LoadingButton components

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Added the new rule and then added an MuiLoadingButton to a page and tried with and without the 'disabled' property.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [x] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
