### PR TITLE
HWP-427: Fixed post tagging

### DIFF
--- a/app/server/routes/v1/post/postTags.js
+++ b/app/server/routes/v1/post/postTags.js
@@ -180,9 +180,9 @@ router.post("/:id", async (req, res) => {
       await Post.updateOne(
         {
           _id: documents.post.id,
-          flags: { $elemMatch: { tag: req.query.tag } },
+          tags: { $elemMatch: { tag: req.query.tag } },
         },
-        { $addToSet: { "tags.$.taggedBy": [documents.user.id] } }
+        { $addToSet: { "tags.$.taggedBy": documents.user.id } }
       );
       req.log.addAction("User added to taggedBy.");
     }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- When a second user tried to tag a post that was previously tagged, it would not set the tag.

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Used swagger to tag a post with one account, and then tagged the same post on a second account.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
