### PR TITLE
HWP-382: Order communities by latestActivity

### DIFF
--- a/app/server/routes/v1/community/community.js
+++ b/app/server/routes/v1/community/community.js
@@ -279,7 +279,7 @@ router.post("/", async (req, res) => {
  *      tags:
  *        - Community
  *      summary: Get all communities or only communities user is a part of.
- *      description: Use optional query 'orderBy' with<br>'lastJoined' - Communities user has joined, in the order of last joined first.<br>'engagement' - Communities user has joined, in the order of most engagement.
+ *      description: Use optional query 'orderBy' with<br>'lastJoined' - Communities user has joined, in the order of last joined first.<br>'engagement' - Communities user has joined, in the order of most engagement.<br>'latestActivity' - Communities user has joined, in the order of latestActivity.
  *      parameters:
  *        - in: query
  *          required: false
@@ -363,6 +363,12 @@ router.get("/", async (req, res) => {
         },
         { $sort: { engagement: -1, _id: -1 } },
       ]).exec();
+    } else if (req.query.orderBy === "latestActivity") {
+      // Order by latestActivity, only communities user is a member of.
+      req.log.addAction("Ordering by latestActivity. Finding communities.");
+      communities = await Community.find({ members: documents.user.id }, "", {
+        sort: { latestActivity: -1 },
+      }).exec();
     } else {
       // Ordered by last created
       req.log.addAction("Ordering by last created. Finding communities.");

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,20 +28,20 @@ services:
   #############################################################################################
   ###                                     React Frontend                                    ###
   #############################################################################################
-  # hwp-frontend:
-  #   container_name: hwp-frontend
-  #   build:
-  #     context: .
-  #     dockerfile: ./app/client/Dockerfile
-  #     args:
-  #       env: ${ENV_FILE:-.env-template}
-  #   networks:
-  #     - hwp-network
-  #   ports:
-  #     - ${FRONTEND_PORT:-8080}:${FRONTEND_PORT:-8080}
-  #   volumes:
-  #     - .:/usr/src/app/
-  #     - /usr/src/app/node_modules
+  hwp-frontend:
+    container_name: hwp-frontend
+    build:
+      context: .
+      dockerfile: ./app/client/Dockerfile
+      args:
+        env: ${ENV_FILE:-.env-template}
+    networks:
+      - hwp-network
+    ports:
+      - ${FRONTEND_PORT:-8080}:${FRONTEND_PORT:-8080}
+    volumes:
+      - .:/usr/src/app/
+      - /usr/src/app/node_modules
 
   #############################################################################################
   ###                                     Express API                                       ###


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added value "latestActivity" to "orderBy" optional query param on [GET API/COMMUNITY](https://hwp-express-api-d63404-dev.apps.silver.devops.gov.bc.ca/api-docs/#/Community/get_api_community). Returns only communities user is a member of and orders by latestActivity.

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Swagger. Tested the new "latestActivity" value in "orderBy" on GET API/COMMUNITY.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

**It seems part of docker-compose was commented out in a previous change, I have just uncommented that.**

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
