### PR TITLE
Undefined Community Name Fix

### DIFF
--- a/app/server/versions/v1/routes/community/community.js
+++ b/app/server/versions/v1/routes/community/community.js
@@ -474,6 +474,14 @@ router.patch("/:title", async (req, res, next) => {
     ]);
     req.log.addAction("Edit query has been cleaned.");
 
+    req.log.addAction("Checking if changes includes title.");
+    if (!query.title) {
+      query.title = req.params.title;
+      req.log.addAction(
+        "Changes does not include title, adding title to changes object."
+      );
+    }
+
     req.log.addAction("Updating community.");
     await Community.updateOne({ title: community.title }, query).exec();
     req.log.addAction("Community updated.");


### PR DESCRIPTION
# Description

Previously, when editing a community, if you did not specify a title in the changes object, the title would be set as undefined in the database.

This PR includes the following proposed change(s):

- Added check in community.js if the community name doesn't exist, if so it adds the community name from params

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [x] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
