### PR TITLE
HWP-475: Hidden and pinned posts

### DIFF
--- a/app/client/src/components/Comment.jsx
+++ b/app/client/src/components/Comment.jsx
@@ -14,11 +14,13 @@ import {
   Typography,
   Button,
   Box,
+  Tooltip,
 } from "@mui/material";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import UpIcon from "@mui/icons-material/KeyboardArrowUp";
 import DownIcon from "@mui/icons-material/KeyboardArrowDown";
 import DeleteForeverTwoToneIcon from "@mui/icons-material/DeleteForeverTwoTone";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import React, { useState } from "react";
 import {
   openDeleteCommentModal,
@@ -178,24 +180,43 @@ export const Comment = (props) => {
               </IconButton>
             </Stack>
           </Box>
-          <Card style={{ margin: 10, width: "100%" }}>
+          <Card
+            style={{
+              margin: 10,
+              width: "100%",
+            }}
+          >
             <CardHeader
               title={
-                <Typography
-                  variant="h5"
-                  sx={{
-                    display: "inline-block",
-                    ":hover": {
-                      textDecoration: "underline",
-                      cursor: "pointer",
-                    },
-                  }}
-                  onClick={() =>
-                    handleCommentCreatorClick(props.comment.creatorUsername)
-                  }
+                <Stack
+                  spacing={0.5}
+                  direction="row"
+                  sx={{ alignItems: "center" }}
                 >
-                  {props.comment.creatorName || "Unknown Commenter"}
-                </Typography>
+                  {props.comment.hidden && (
+                    <Tooltip
+                      title={<Typography>Hidden Comment</Typography>}
+                      arrow
+                    >
+                      <VisibilityOffIcon />
+                    </Tooltip>
+                  )}
+                  <Typography
+                    variant="h5"
+                    sx={{
+                      display: "inline-block",
+                      ":hover": {
+                        textDecoration: "underline",
+                        cursor: "pointer",
+                      },
+                    }}
+                    onClick={() =>
+                      handleCommentCreatorClick(props.comment.creatorUsername)
+                    }
+                  >
+                    {props.comment.creatorName || "Unknown Commenter"}
+                  </Typography>
+                </Stack>
               }
               subheader={<Typography fontSize="small">{createdOn}</Typography>}
               avatar={
@@ -248,10 +269,12 @@ export const Comment = (props) => {
                   </>
                 )
               }
-              sx={{ backgroundColor: "card.main" }}
             />
             <CardContent
-              sx={{ paddingTop: "0px", backgroundColor: "card.main" }}
+              sx={{
+                paddingTop: "0px",
+                backgroundColor: "card.main",
+              }}
             >
               {props.comment.edits.length > 0 && (
                 <Typography variant="caption" color="#898989">

--- a/app/client/src/components/Post.jsx
+++ b/app/client/src/components/Post.jsx
@@ -13,7 +13,7 @@ import {
   MenuList,
   Typography,
   Stack,
-  Button,
+  Tooltip,
 } from "@mui/material";
 import FlagTwoToneIcon from "@mui/icons-material/FlagTwoTone";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
@@ -27,6 +27,8 @@ import {
 import { useState } from "react";
 import DeleteForeverTwoToneIcon from "@mui/icons-material/DeleteForeverTwoTone";
 import EditTwoToneIcon from "@mui/icons-material/EditTwoTone";
+import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
+import PushPinIcon from "@mui/icons-material/PushPin";
 import TagsList from "./TagsList";
 import { useParams } from "react-router-dom";
 import { getPost } from "../redux/ducks/postDuck";
@@ -35,6 +37,7 @@ import CommentIcon from "@mui/icons-material/Comment";
 import moment from "moment";
 import MDEditor from "@uiw/react-md-editor";
 import { getDarkModePreference } from "../theme";
+import { editPost } from "../redux/ducks/postDuck";
 
 const Post = (props) => {
   const maxTitleLength = 45;
@@ -46,9 +49,40 @@ const Post = (props) => {
 
   let { id } = useParams();
 
+  // TODO: Get if user is moderator
+  const isModerator = false;
+
   const navigate = useNavigate();
 
   const post = props.post;
+
+  const editPost = async (field) => {
+    let post = {};
+    switch (field) {
+      case "pinned":
+        post = {
+          id: props.post._id,
+          title: props.post.title,
+          message: props.post.message,
+          pinned: !props.post.pinned,
+          hidden: props.post.hidden,
+        };
+        break;
+      case "hidden":
+        post = {
+          id: props.post._id,
+          title: props.post.title,
+          message: props.post.message,
+          pinned: props.post.pinned,
+          hidden: !props.post.hidden,
+        };
+        break;
+      default:
+        return;
+    }
+
+    await props.editPost(post);
+  };
 
   const handleFlagPostClick = () => {
     props.openFlagPostModal(post);
@@ -119,7 +153,11 @@ const Post = (props) => {
         square
       >
         <CardHeader
-          sx={{ backgroundColor: "banner.main", color: "white", py: 1 }}
+          sx={{
+            backgroundColor: props.post.hidden ? "#9C9C9C" : "banner.main",
+            color: "white",
+            py: 1,
+          }}
           action={
             <>
               <IconButton aria-label="settings" onClick={handleMenuOpen}>
@@ -137,21 +175,41 @@ const Post = (props) => {
                     </ListItemIcon>
                     <ListItemText>Flag</ListItemText>
                   </MenuItem>
+                  {(props.userId === post.creator || isModerator) && (
+                    <MenuItem onClick={handleDeletePostClick}>
+                      <ListItemIcon>
+                        <DeleteForeverTwoToneIcon fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>Delete</ListItemText>
+                    </MenuItem>
+                  )}
                   {props.userId === post.creator && (
-                    <Box>
-                      <MenuItem onClick={handleDeletePostClick}>
+                    <MenuItem onClick={handleEditPostClick}>
+                      <ListItemIcon>
+                        <EditTwoToneIcon fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText>Edit</ListItemText>
+                    </MenuItem>
+                  )}
+                  {isModerator && (
+                    <>
+                      <MenuItem onClick={() => editPost("hidden")}>
                         <ListItemIcon>
-                          <DeleteForeverTwoToneIcon fontSize="small" />
+                          <VisibilityOffIcon fontSize="small" />
                         </ListItemIcon>
-                        <ListItemText>Delete</ListItemText>
+                        <ListItemText>
+                          {props.post.hidden ? "Show" : "Hide"}
+                        </ListItemText>
                       </MenuItem>
-                      <MenuItem onClick={handleEditPostClick}>
+                      <MenuItem onClick={() => editPost("pinned")}>
                         <ListItemIcon>
-                          <EditTwoToneIcon fontSize="small" />
+                          <PushPinIcon fontSize="small" />
                         </ListItemIcon>
-                        <ListItemText>Edit</ListItemText>
+                        <ListItemText>
+                          {props.post.pinned ? "Unpin" : "Pin"}
+                        </ListItemText>
                       </MenuItem>
-                    </Box>
+                    </>
                   )}
                 </MenuList>
               </Menu>
@@ -160,19 +218,35 @@ const Post = (props) => {
           title={
             <Grid container spacing={2}>
               <Grid item xs={9}>
-                <Typography
-                  variant="h6"
-                  onClick={handlePostClick}
-                  sx={{
-                    cursor: props.isPostPage || "pointer",
-                  }}
+                <Stack
+                  direction="row"
+                  spacing={0.5}
+                  sx={{ alignItems: "center" }}
                 >
-                  <b>
-                    {post.title.length >= maxTitleLength
-                      ? post.title.substring(0, maxTitleLength) + "..."
-                      : post.title}
-                  </b>
-                </Typography>
+                  {props.post.hidden && (
+                    <Tooltip title={<Typography>Hidden Post</Typography>} arrow>
+                      <VisibilityOffIcon />
+                    </Tooltip>
+                  )}
+                  {props.post.pinned && (
+                    <Tooltip title={<Typography>Pinned Post</Typography>} arrow>
+                      <PushPinIcon />
+                    </Tooltip>
+                  )}
+                  <Typography
+                    variant="h6"
+                    onClick={handlePostClick}
+                    sx={{
+                      cursor: props.isPostPage || "pointer",
+                    }}
+                  >
+                    <b>
+                      {post.title.length >= maxTitleLength
+                        ? post.title.substring(0, maxTitleLength) + "..."
+                        : post.title}
+                    </b>
+                  </Typography>
+                </Stack>
               </Grid>
               <Grid item xs={3}>
                 <Typography
@@ -276,6 +350,7 @@ const mapActionsToProps = {
   openDeletePostModal,
   openEditPostModal,
   getPost,
+  editPost,
 };
 
 export default connect(mapStateToProps, mapActionsToProps)(Post);

--- a/app/client/src/components/modals/EditPostModal.jsx
+++ b/app/client/src/components/modals/EditPostModal.jsx
@@ -82,6 +82,7 @@ const EditPostModal = (props) => {
       title: title || props.post.title,
       message: message || props.post.message,
       pinned: props.post.pinned,
+      hidden: props.post.hidden,
     };
 
     const successful = await props.editPost(post);

--- a/app/client/src/redux/ducks/postDuck.js
+++ b/app/client/src/redux/ducks/postDuck.js
@@ -709,6 +709,7 @@ export function postReducer(state = initialState, action) {
                 title: action.payload.title,
                 message: action.payload.message,
                 pinned: action.payload.pinned,
+                hidden: action.payload.hidden,
               }
             : post
         ),


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Still requires the code to be implemented that tells if the user is a moderator or not. **To test**, look for variable `isModerator`.
- Styles the post header to gray and adds a "Not Visible" icon to posts that are hidden (hidden posts are only visible to community moderators).
- Adds a "pinned" icon to post headers that are pinned.
- Adds menu options on posts for pinning/un-pinning and hiding/showing the post (only available to community moderators).
- **Requires:** https://github.com/bcgov/CITZ-HybridWorkplace/pull/362 To allow editing of posts that are not created by you.

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Set `isModerator` to true to test pinning and hiding posts. Set to false to see that regular users can't see the menu options.
**Requires:** https://github.com/bcgov/CITZ-HybridWorkplace/pull/362 To allow editing of posts that are not created by you.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [x] Tested by Brandon.
- [x] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
