### PR TITLE
HWP-304: Moderator permissions modal

### DIFF
--- a/app/client/src/components/modals/EditModPermsModal.jsx
+++ b/app/client/src/components/modals/EditModPermsModal.jsx
@@ -1,0 +1,200 @@
+//
+// Copyright © 2022 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/**
+ * Application entry point
+ * @author [Brady Mitchell](braden.jr.mitch@gmail.com)
+ * @module
+ */
+
+import React, { useEffect, useState } from "react";
+import { connect } from "react-redux";
+import {
+  Button,
+  Typography,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Stack,
+  Checkbox,
+  DialogActions,
+} from "@mui/material";
+import WarningIcon from "@mui/icons-material/Warning";
+
+import { closeEditModeratorPermissionsModal } from "../../redux/ducks/modalDuck";
+import { editCommunityModeratorPermissions } from "../../redux/ducks/communityDuck";
+
+const EditModPermsModal = (props) => {
+  const [moderatorUsername, setModeratorUsername] = useState("");
+  const [moderatorName, setModeratorName] = useState("");
+
+  const [setModeratorsPerm, setSetModeratorsPerm] = useState(false);
+  const [setPermissionsPerm, setSetPermissionsPerm] = useState(false);
+  const [removeCommunityPerm, setRemoveCommunityPerm] = useState(false);
+
+  const onSetModeratorsPermChange = (event) => {
+    setSetModeratorsPerm(event.target.checked);
+  };
+
+  const onSetPermissionsPermChange = (event) => {
+    setSetPermissionsPerm(event.target.checked);
+  };
+
+  const onRemoveCommunityPermChange = (event) => {
+    setRemoveCommunityPerm(event.target.checked);
+  };
+
+  useEffect(() => {
+    setModeratorUsername(props.moderator?.username ?? "");
+    setModeratorName(props.moderator?.name ?? "");
+    if (props.moderator?.permissions?.includes("set_moderators"))
+      setSetModeratorsPerm(true);
+    if (props.moderator?.permissions?.includes("set_permissions"))
+      setSetPermissionsPerm(true);
+    if (props.moderator?.permissions?.includes("remove_community"))
+      setRemoveCommunityPerm(true);
+  }, [props.moderator]);
+
+  const formatPermissionsArray = () => {
+    const perms = [];
+    if (setModeratorsPerm) perms.push("set_moderators");
+    if (setPermissionsPerm) perms.push("set_permissions");
+    if (removeCommunityPerm) perms.push("remove_community");
+    return perms;
+  };
+
+  const registerPermissions = async () => {
+    const moderator = {
+      community: props.community,
+      username: moderatorUsername,
+      permissions: formatPermissionsArray(),
+    };
+
+    const successful = await props.editCommunityModeratorPermissions(
+      moderator ?? {}
+    );
+    if (successful === true) {
+      setModeratorUsername("");
+      setModeratorName("");
+      setSetModeratorsPerm(false);
+      setSetPermissionsPerm(false);
+      setRemoveCommunityPerm(false);
+      props.closeEditModeratorPermissionsModal();
+    }
+  };
+
+  return (
+    <Dialog
+      open={props.open}
+      onClose={props.closeEditModeratorPermissionsModal}
+      sx={{ zIndex: 500, mb: 5 }}
+      fullWidth
+    >
+      <DialogTitle fontWeight={600}>Edit Moderator Permissions</DialogTitle>
+      <DialogContent>
+        <Stack spacing={0.5}>
+          <Typography>Username: {moderatorUsername}</Typography>
+          <Typography>Full Name: {moderatorName}</Typography>
+          <Stack spacing={1}>
+            <Stack
+              direction="row"
+              spacing={0.5}
+              sx={{ alignItems: "center", display: "flex" }}
+            >
+              <Checkbox
+                checked={setModeratorsPerm}
+                onChange={onSetModeratorsPermChange}
+              />
+              <Typography>
+                Moderator can add and remove other moderators.
+              </Typography>
+            </Stack>
+            <Stack
+              direction="row"
+              spacing={0.5}
+              sx={{ alignItems: "center", display: "flex" }}
+            >
+              <Checkbox
+                checked={setPermissionsPerm}
+                onChange={onSetPermissionsPermChange}
+              />
+              <Typography>
+                Moderator can set other moderators permissions.
+              </Typography>
+            </Stack>
+            <Stack spacing={0.5} direction="row">
+              <WarningIcon fontSize="small" sx={{ color: "#FD1B1B" }} />
+              <Typography sx={{ color: "#FD1B1B" }}>
+                WARNING: This permission should only be given to the most
+                trusted of moderators. They will be able to set any permission
+                on other moderators, including themselves.
+              </Typography>
+            </Stack>
+            <Stack
+              direction="row"
+              spacing={0.5}
+              sx={{ alignItems: "center", display: "flex" }}
+            >
+              <Checkbox
+                checked={removeCommunityPerm}
+                onChange={onRemoveCommunityPermChange}
+              />
+              <Typography>Moderator can remove the community.</Typography>
+            </Stack>
+            <Stack spacing={0.5} direction="row">
+              <WarningIcon fontSize="small" sx={{ color: "#FD1B1B" }} />
+              <Typography sx={{ color: "#FD1B1B" }}>
+                WARNING: This permission should only be given to the most
+                trusted of moderators. They will be able to remove the entire
+                community. Admins can undo these actions, but it's best to
+                prevent this situation in the first place.
+              </Typography>
+            </Stack>
+          </Stack>
+          <DialogActions
+            sx={{
+              m: 0,
+              pb: 0,
+            }}
+          >
+            <Stack spacing={1} direction="row-reverse" justifyContent="end">
+              <Button variant="contained" onClick={registerPermissions}>
+                Submit
+              </Button>
+              <Button
+                variant="contained"
+                onClick={props.closeEditModeratorPermissionsModal}
+              >
+                Cancel
+              </Button>
+            </Stack>
+          </DialogActions>
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const mapStateToProps = (state) => ({
+  auth: state.auth,
+  moderator: state.modal.editModPermissions.moderator,
+  open: state.modal.editModPermissions.open,
+});
+
+export default connect(mapStateToProps, {
+  editCommunityModeratorPermissions,
+  closeEditModeratorPermissionsModal,
+})(EditModPermsModal);

--- a/app/client/src/redux/ducks/communityDuck.js
+++ b/app/client/src/redux/ducks/communityDuck.js
@@ -40,6 +40,8 @@ const LEAVE_COMMUNITY = "CITZ-HYBRIDWORKPLACE/COMMUNITY/LEAVE_COMMUNITY";
 const DELETE_COMMUNITY = "CITZ-HYBRIDWORKPLACE/COMMUNITY/DELETE_COMMUNITY";
 const GET_COMMUNITY_POSTS =
   "CITZ-HYBRIDWORKPLACE/COMMUNITY/GET_COMMUNITY_POSTS";
+const EDIT_COMMUNITY_MODERATOR_PERMISSIONS =
+  "CITZ-HYBRIDWORKPLACE/COMMUNITY/EDIT_COMMUNITY_MODERATOR_PERMISSIONS";
 
 const noTokenText = "Trying to access accessToken, no accessToken in store";
 
@@ -102,7 +104,6 @@ export const getCommunities = () => async (dispatch, getState) => {
       authState.user.id,
       response.data
     );
-    console.log(response.data);
 
     dispatch({
       type: SET_COMMUNITIES,
@@ -358,6 +359,41 @@ export const editCommunity = (newCommunity) => async (dispatch, getState) => {
   }
 };
 
+export const editCommunityModeratorPermissions =
+  (moderator) => async (dispatch, getState) => {
+    let successful = true;
+    try {
+      const authState = getState().auth;
+      const token = authState.accessToken;
+      if (!token) throw new Error(noTokenText);
+
+      const response = await hwp_axios.patch(
+        `/api/community/moderators/permissions/${moderator.community}`,
+        {
+          ...moderator,
+        },
+        {
+          headers: {
+            authorization: `Bearer ${token}`,
+          },
+          params: {
+            dispatch,
+          },
+        }
+      );
+
+      dispatch({
+        type: EDIT_COMMUNITY_MODERATOR_PERMISSIONS,
+        payload: moderator,
+      });
+    } catch (err) {
+      console.error(err);
+      successful = false;
+    } finally {
+      return successful;
+    }
+  };
+
 const initialState = {
   currentCommunityIndex: -1,
   communities: [],
@@ -457,6 +493,22 @@ export function communityReducer(state = initialState, action) {
           (item) => item.title !== action.payload
         ),
       };
+    case EDIT_COMMUNITY_MODERATOR_PERMISSIONS:
+      return (() => {
+        const newState = { ...state };
+        //Assigning currentCommunity to be a reference of the community object in the array
+        const commIndex = newState.communities.findIndex(
+          (comm) => comm.title === action.payload.community
+        );
+        const modIndex = newState.communities[commIndex].moderators.findIndex(
+          (mod) => mod.username === action.payload.username
+        );
+        newState.communities[commIndex].moderators[modIndex].permissions =
+          action.payload.permissions ??
+          newState.communities[commIndex].moderators[modIndex].permissions;
+
+        return newState;
+      })();
     default:
       return state;
   }

--- a/app/client/src/redux/ducks/modalDuck.js
+++ b/app/client/src/redux/ducks/modalDuck.js
@@ -75,6 +75,10 @@ const OPEN_EDIT_AVATAR_MODAL =
   "CITZ-HYBRIDWORKPLACE/EDIT/OPEN_EDIT_AVATAR_MODAL";
 const CLOSE_EDIT_AVATAR_MODAL =
   "CITZ-HYBRIDWORKPLACE/EDIT/CLOSE_EDIT_AVATAR_MODAL";
+const OPEN_EDIT_MODERATOR_PERMISSIONS_MODAL =
+  "CITZ-HYBRIDWORKPLACE/EDIT/OPEN_EDIT_MODERATOR_PERMISSIONS_MODAL";
+const CLOSE_EDIT_MODERATOR_PERMISSIONS_MODAL =
+  "CITZ-HYBRIDWORKPLACE/EDIT/CLOSE_EDIT_MODERATOR_PERMISSIONS_MODAL";
 
 /*************************ADD TYPES*************************/
 const OPEN_ADD_POST_MODAL = "CITZ-HYBRIDWORKPLACE/ADD/OPEN_ADD_POST_MODAL";
@@ -182,6 +186,16 @@ export const openEditAvatarModal = (avatar) => (dispatch) => {
 export const closeEditAvatarModal = () => (dispatch) =>
   dispatch({ type: CLOSE_EDIT_AVATAR_MODAL });
 
+export const openEditModeratorPermissionsModal = (moderator) => (dispatch) => {
+  dispatch({
+    type: OPEN_EDIT_MODERATOR_PERMISSIONS_MODAL,
+    payload: moderator,
+  });
+};
+
+export const closeEditModeratorPermissionsModal = () => (dispatch) =>
+  dispatch({ type: CLOSE_EDIT_MODERATOR_PERMISSIONS_MODAL });
+
 /*********************** ADD MODAL ACTIONS***********************/
 
 export const openAddPostModal = () => (dispatch) => {
@@ -218,6 +232,7 @@ const initialState = {
   editAvatar: { open: false, avatar: {} },
   editUserInterests: { open: false, interests: {} },
   editSettings: { open: false, userSettings: {} },
+  editModPermissions: { open: false, moderator: {} },
   // Add State
   addPost: { open: false },
   addCommunity: { open: false },
@@ -365,6 +380,15 @@ export function modalReducer(state = initialState, action) {
 
     case CLOSE_EDIT_COMMUNITY_MODAL:
       return initialState;
+
+    case CLOSE_EDIT_MODERATOR_PERMISSIONS_MODAL:
+      return initialState;
+
+    case OPEN_EDIT_MODERATOR_PERMISSIONS_MODAL:
+      return {
+        ...state,
+        editModPermissions: { open: true, moderator: action.payload },
+      };
 
     default:
       return state;

--- a/app/client/src/views/CommunityPage.jsx
+++ b/app/client/src/views/CommunityPage.jsx
@@ -55,7 +55,11 @@ import PostModal from "../components/modals/AddPostModal";
 import JoinButton from "../components/JoinButton";
 import { openEditCommunityModal } from "../redux/ducks/modalDuck";
 import EditCommunityModal from "../components/modals/EditCommunityModal";
-import { openAddPostModal } from "../redux/ducks/modalDuck";
+import EditModPermsModal from "../components/modals/EditModPermsModal";
+import {
+  openAddPostModal,
+  openEditModeratorPermissionsModal,
+} from "../redux/ducks/modalDuck";
 import {
   getCommunityPosts,
   getCommunity,
@@ -120,6 +124,17 @@ const CommunityPage = (props) => {
 
   const handleCommunityCreatorClick = (creator) => {
     if (creator) navigate(`/profile/${creator}`);
+  };
+
+  const handleEditModeratorPermissionsClick = (username) => {
+    handleMenuClose();
+    let moderator = {};
+    Object.keys(props.community.moderators).forEach((key) => {
+      if (props.community.moderators[key].username === username) {
+        moderator = props.community.moderators[key];
+      }
+    });
+    props.openEditModeratorPermissionsModal(moderator);
   };
 
   const [showFlaggedPosts, setShowFlaggedPosts] = useState(false);
@@ -326,7 +341,13 @@ const CommunityPage = (props) => {
                                 anchorEl={anchorEl}
                               >
                                 <MenuList>
-                                  <MenuItem>
+                                  <MenuItem
+                                    onClick={() =>
+                                      handleEditModeratorPermissionsClick(
+                                        props.community.moderators[key].username
+                                      )
+                                    }
+                                  >
                                     <ListItemIcon>
                                       <EditAttributesIcon fontSize="small" />
                                     </ListItemIcon>
@@ -408,6 +429,7 @@ const CommunityPage = (props) => {
         </Grid>
       </Grid>
       <EditCommunityModal />
+      <EditModPermsModal community={props.community.title} />
     </Box>
   );
 };
@@ -432,6 +454,7 @@ const mapDispatchToProps = {
   getUsersCommunities,
   getCommunity,
   openEditCommunityModal,
+  openEditModeratorPermissionsModal,
   openAddPostModal,
   joinCommunity,
 };

--- a/app/client/src/views/CommunityPage.jsx
+++ b/app/client/src/views/CommunityPage.jsx
@@ -68,6 +68,7 @@ import {
 } from "../redux/ducks/communityDuck";
 import LoadingPage from "./LoadingPage";
 import CommunityNotFoundPage from "./CommunityNotFoundPage";
+import { isUserModerator } from "../helperFunctions/communityHelpers";
 
 const CommunityPage = (props) => {
   const navigate = useNavigate();
@@ -136,6 +137,14 @@ const CommunityPage = (props) => {
     });
     props.openEditModeratorPermissionsModal(moderator);
   };
+
+  let modPermissions = [];
+  if (props.community.moderators)
+    Object.keys(props.community.moderators).forEach((key) => {
+      if (props.community.moderators[key].userId === props.userId) {
+        modPermissions = props.community.moderators[key].permissions;
+      }
+    });
 
   const [showFlaggedPosts, setShowFlaggedPosts] = useState(false);
 
@@ -341,20 +350,26 @@ const CommunityPage = (props) => {
                                 anchorEl={anchorEl}
                               >
                                 <MenuList>
-                                  <MenuItem
-                                    onClick={() =>
-                                      handleEditModeratorPermissionsClick(
-                                        props.community.moderators[key].username
-                                      )
-                                    }
-                                  >
-                                    <ListItemIcon>
-                                      <EditAttributesIcon fontSize="small" />
-                                    </ListItemIcon>
-                                    <ListItemText>
-                                      Edit Permissions
-                                    </ListItemText>
-                                  </MenuItem>
+                                  {modPermissions &&
+                                    modPermissions.includes(
+                                      "set_permissions"
+                                    ) && (
+                                      <MenuItem
+                                        onClick={() =>
+                                          handleEditModeratorPermissionsClick(
+                                            props.community.moderators[key]
+                                              .username
+                                          )
+                                        }
+                                      >
+                                        <ListItemIcon>
+                                          <EditAttributesIcon fontSize="small" />
+                                        </ListItemIcon>
+                                        <ListItemText>
+                                          Edit Permissions
+                                        </ListItemText>
+                                      </MenuItem>
+                                    )}
                                   <MenuItem>
                                     <ListItemIcon>
                                       <PersonRemoveIcon fontSize="small" />


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added a modal for moderators to edit permissions of other moderators
- Only displays option to set permissions if the moderator has `set_permissions` permission

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Created a test community and edited my own permissions.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
