### PR TITLE
HWP-520: Changes to returned user communities in api/user

### DIFF
--- a/app/server/versions/v1/functions/findCommunitiesByEngagement.js
+++ b/app/server/versions/v1/functions/findCommunitiesByEngagement.js
@@ -40,6 +40,7 @@ const findCommunitiesByEngagement = async (user) => {
           },
           {
             $match: {
+              username: user.username,
               $expr: {
                 $and: [
                   { $eq: ["$communities.community", "$$community_title"] },
@@ -63,7 +64,6 @@ const findCommunitiesByEngagement = async (user) => {
         userData: 0,
       },
     },
-    { $unwind: "$members" },
     {
       $match: {
         members: new ObjectId(user.id),


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Add createdOn, latestActivity, and members fields to communities when returned by GET api/user for better use in the frontend.
- Fix for get communities by engagement, wasn't grabbing engagement data from correct user.

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Swagger.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
