### PR TITLE
Removed Pin Sort for Users Communities Posts

### DIFF
--- a/app/server/versions/v1/routes/post/post.js
+++ b/app/server/versions/v1/routes/post/post.js
@@ -265,7 +265,7 @@ router.get("/", async (req, res, next) => {
 
     req.log.addAction("Communities found. Finding posts from communities.");
     const posts = await Post.find(matchQuery, "", {
-      sort: { pinned: -1, _id: -1 },
+      sort: { _id: -1 },
     }).exec();
 
     if (!posts) throw new ResponseError(404, "Posts not found.");


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Removed sorting by pinned posts when fetching all posts from communities the user is in
  - This prevents pinned posts from having priority on the home screen

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [x] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [ ] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
