### PR TITLE
HWP-512: Community UI tweaks, title length, and postCount

### DIFF
--- a/app/client/src/components/Community.jsx
+++ b/app/client/src/components/Community.jsx
@@ -169,13 +169,11 @@ const Community = (props) => {
             )
           }
           title={
-            <Typography variant="h5">
-              <b>
+            <Typography variant="h5" sx={{ fontWeight: 600 }} >
                 {community.title.length >= maxDisplayedTitleLength
                   ? community.title.substring(0, maxDisplayedTitleLength) +
                     "..."
                   : community.title}
-              </b>
             </Typography>
           }
           subheader={

--- a/app/client/src/components/Community.jsx
+++ b/app/client/src/components/Community.jsx
@@ -19,6 +19,7 @@ import {
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import DeleteForeverTwoToneIcon from "@mui/icons-material/DeleteForeverTwoTone";
 import GroupsIcon from "@mui/icons-material/Groups";
+import FeedIcon from "@mui/icons-material/Feed";
 
 import { useState, useMemo } from "react";
 import { connect } from "react-redux";
@@ -36,6 +37,7 @@ const Community = (props) => {
   const navigate = useNavigate();
 
   const { community } = props;
+  const maxDisplayedTitleLength = 65;
 
   function useQuery() {
     const { search } = useLocation();
@@ -167,14 +169,19 @@ const Community = (props) => {
             )
           }
           title={
-            <Stack direction="row" spacing={3}>
-              <Typography variant="h5">
-                <b>{community.title}</b>
-              </Typography>
-              <Typography size="small" sx={{ pt: "5px" }}>
-                Created {createdOn || "Unknown"}
-              </Typography>
-            </Stack>
+            <Typography variant="h5">
+              <b>
+                {community.title.length >= maxDisplayedTitleLength
+                  ? community.title.substring(0, maxDisplayedTitleLength) +
+                    "..."
+                  : community.title}
+              </b>
+            </Typography>
+          }
+          subheader={
+            <Typography size="small" sx={{ pt: "5px" }}>
+              Created {createdOn || "Unknown"}
+            </Typography>
           }
         />
         <CardContent>
@@ -183,9 +190,25 @@ const Community = (props) => {
         <CardActions>
           <Stack direction="row" spacing={1} width="0.95" alignItems="center">
             <Stack direction="row" spacing={1} sx={{ ml: "5px" }}>
-              <GroupsIcon sx={{ color: "#898989" }} />
+              <Tooltip title={<Typography>Community Members</Typography>} arrow>
+                <GroupsIcon sx={{ color: "#898989" }} />
+              </Tooltip>
               <Typography color="#898989">
                 {community.memberCount || 0}
+              </Typography>
+            </Stack>
+            <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
+              <Tooltip title={<Typography>Community Posts</Typography>} arrow>
+                <IconButton
+                  disableRipple
+                  onClick={handleCommunityClick}
+                  sx={{ pr: 0 }}
+                >
+                  <FeedIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Typography color="#898989">
+                {community.postCount || 0}
               </Typography>
             </Stack>
             <JoinButton community={community} />

--- a/app/client/src/components/Post.jsx
+++ b/app/client/src/components/Post.jsx
@@ -48,7 +48,7 @@ const Post = (props) => {
       await props.getCommunity(props.post.community);
     })();
   }, []);
-  const maxTitleLength = 45;
+  const maxTitleLength = 58;
   const maxCommunityTitleLength = 16;
   const maxMessageLines = 5;
 

--- a/app/client/src/components/UsersCommunitiesList.jsx
+++ b/app/client/src/components/UsersCommunitiesList.jsx
@@ -25,14 +25,24 @@ import { connect } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import PropTypes from "prop-types";
 
-import { Paper, Box, Grid, Stack, Typography } from "@mui/material";
+import {
+  Paper,
+  Box,
+  Grid,
+  Stack,
+  Typography,
+  Tooltip,
+  IconButton,
+} from "@mui/material";
 import GroupsIcon from "@mui/icons-material/Groups";
+import FeedIcon from "@mui/icons-material/Feed";
 
 import { getUsersCommunities } from "../redux/ducks/communityDuck";
 import JoinButton from "./JoinButton";
 
 const UsersCommunitiesList = (props) => {
   const navigate = useNavigate();
+  const maxDisplayedTitleLength = 65;
 
   useEffect(() => {
     props.getUsersCommunities();
@@ -70,14 +80,40 @@ const UsersCommunitiesList = (props) => {
               <Grid container>
                 <Grid item xs={12}>
                   <Typography p={1.5} variant="h7" component="p">
-                    <b>{community.title}</b>
+                    <b>
+                      {community.title.length >= maxDisplayedTitleLength
+                        ? community.title.substring(
+                            0,
+                            maxDisplayedTitleLength
+                          ) + "..."
+                        : community.title}
+                    </b>
                   </Typography>
                 </Grid>
                 <Grid item xs={12} sx={{ pt: 0, pb: "10px" }}>
-                  <Stack direction="row" spacing={1} sx={{ ml: "15px" }}>
+                  <Stack
+                    direction="row"
+                    spacing={1}
+                    sx={{ ml: "15px", alignItems: "center" }}
+                  >
                     <GroupsIcon sx={{ color: "#898989" }} />
                     <Typography color="#898989">
                       {community.memberCount || 0}
+                    </Typography>
+                    <Tooltip
+                      title={<Typography>Community Posts</Typography>}
+                      arrow
+                    >
+                      <IconButton
+                        disableRipple
+                        onClick={handleCommunityClick}
+                        sx={{ pr: 0 }}
+                      >
+                        <FeedIcon fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                    <Typography color="#898989">
+                      {community.postCount || 0}
                     </Typography>
                   </Stack>
                 </Grid>

--- a/app/client/src/components/modals/AddCommunityModal.jsx
+++ b/app/client/src/components/modals/AddCommunityModal.jsx
@@ -115,11 +115,11 @@ const AddCommunityModal = (props) => {
               type="text"
               placeholder="Title"
               error={
-                title === "" || (title.length >= 3 && title.length <= 25)
+                title === "" || (title.length >= 3 && title.length <= 200)
                   ? false
                   : true
               }
-              helperText="Title must be 3-25 characters in length."
+              helperText="Title must be 3-200 characters in length."
               required
             />
           </Stack>
@@ -238,7 +238,7 @@ const AddCommunityModal = (props) => {
                 loading={createCommunityLoading}
                 disabled={
                   title.length < 3 ||
-                  title.length > 25 ||
+                  title.length > 200 ||
                   description.length < 3 ||
                   description.length > 300
                 }

--- a/app/client/src/components/modals/AddPostModal.jsx
+++ b/app/client/src/components/modals/AddPostModal.jsx
@@ -31,7 +31,6 @@ import {
   DialogContent,
   DialogTitle,
   Select,
-  Typography,
   Button,
   Stack,
   Box,
@@ -47,7 +46,7 @@ import MarkDownEditor from "../MarkDownEditor";
 const AddPostModal = (props) => {
   // TODO: Grab length options from API
   const minTitleLength = 3;
-  const maxTitleLength = 50;
+  const maxTitleLength = 200;
   const minMessageLength = 3;
   const maxMessageLength = 40000;
 
@@ -177,7 +176,9 @@ const AddPostModal = (props) => {
               >
                 Post
               </Button>
-              <Button onClick={props.closeAddPostModal} color="button">Cancel</Button>
+              <Button onClick={props.closeAddPostModal} color="button">
+                Cancel
+              </Button>
             </Stack>
           </DialogActions>
         </Stack>

--- a/app/client/src/components/modals/EditCommunityModal.jsx
+++ b/app/client/src/components/modals/EditCommunityModal.jsx
@@ -81,7 +81,10 @@ const EditCommunityModal = (props) => {
       props.createError("Modifying a community requires at least one change.");
       return;
     }
-    const successful = await props.editCommunity(changes);
+    const successful = await props.editCommunity(
+      props.community.title,
+      changes
+    );
     if (successful) {
       // To be uncommented when backend supports community title change
       //navigate(`/community/${newComm.title || props.community.title}`);
@@ -110,11 +113,11 @@ const EditCommunityModal = (props) => {
             size="small"
             error={
               !title ||
-              (title === "" || (title.length >= 3 && title.length <= 25)
+              (title === "" || (title.length >= 3 && title.length <= 200)
                 ? false
                 : true)
             }
-            helperText="Title must be 3-25 characters in length."
+            helperText="Title must be 3-200 characters in length."
             required
           />
           <MarkDownEditor
@@ -140,7 +143,7 @@ const EditCommunityModal = (props) => {
                   title &&
                   description &&
                   (title.length < 3 ||
-                    title.length > 25 ||
+                    title.length > 200 ||
                     description.length < 3 ||
                     description.length > 300)
                 }

--- a/app/client/src/components/modals/EditPostModal.jsx
+++ b/app/client/src/components/modals/EditPostModal.jsx
@@ -43,7 +43,7 @@ import MarkDownEditor from "../MarkDownEditor";
 
 const EditPostModal = (props) => {
   const minTitleLength = 3;
-  const maxTitleLength = 50;
+  const maxTitleLength = 200;
   const minMessageLength = 3;
   const maxMessageLength = 40000;
 

--- a/app/client/src/views/CommunityPage.jsx
+++ b/app/client/src/views/CommunityPage.jsx
@@ -300,7 +300,7 @@ const CommunityPage = (props) => {
               border: 0,
             }}
           >
-            <Stack spacing={1} sx={{ pb: 3 }}>
+            <Stack spacing={1} sx={{ pb: 3, pt: 1.5 }}>
               <MarkDownDisplay message={props.community.description} />
               <Button
                 variant="text"

--- a/app/server/versions/v1/db/init/optionsCollection.js
+++ b/app/server/versions/v1/db/init/optionsCollection.js
@@ -46,7 +46,7 @@ const options = [
     component: "community",
     options: {
       titleMinLength: 3,
-      titleMaxLength: 25,
+      titleMaxLength: 200,
       titleDisallowedCharacters: "\\\\/@\\*\\^_\\+\\-=`~\\]\\[{}:;<>",
       titleDisallowedStrings: [
         "www.",


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Community card shows icon and number to display how many posts are in the community.
- Community title max length increased to 200.
- Made changes to allow setting of 200 character post titles in frontend.
- Moved "Created on" label for communities to the subheader.

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Visible in frontend. Tested max community and title lengths.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [ ] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
