### PR TITLE
HWP-517: Added online status

### DIFF
--- a/app/server/express.js
+++ b/app/server/express.js
@@ -31,6 +31,7 @@ const initLogger = require(`./versions/v${process.env.API_VERSION}/middleware/in
 const authenticateToken = require(`./versions/v${process.env.API_VERSION}/middleware/authenticateToken`);
 const sanitizeInputs = require(`./versions/v${process.env.API_VERSION}/middleware/sanitizeInputs`);
 const requestFinally = require(`./versions/v${process.env.API_VERSION}/middleware/requestFinally`);
+const setOnlineStatus = require(`./versions/v${process.env.API_VERSION}/middleware/setOnlineStatus`);
 const cors = require("cors");
 const cookieParser = require("cookie-parser");
 const rateLimit = require("express-rate-limit");
@@ -63,6 +64,7 @@ const {
   healthCheckRouter,
   tokenRouter,
   searchRouter,
+  onlineStatusRouter,
 } = require(`./versions/v${process.env.API_VERSION}/routes/routeImports`);
 
 const keycloakRouter = require(`./versions/v${process.env.API_VERSION}/routes/keycloakLogin`);
@@ -138,13 +140,29 @@ app.use("/api/login", initLogger, loginRouter, requestFinally);
 app.use("/api/logout", initLogger, logoutRouter, requestFinally);
 app.use("/api/token", initLogger, tokenRouter, requestFinally);
 
-app.use("/api/search", initLogger, authenticateToken, searchRouter, requestFinally);
+app.use(
+  "/api/search",
+  initLogger,
+  authenticateToken,
+  searchRouter,
+  setOnlineStatus,
+  requestFinally
+);
+
+app.use(
+  "/api/online",
+  initLogger,
+  authenticateToken,
+  onlineStatusRouter,
+  requestFinally
+);
 
 app.use(
   "/api/community/moderators",
   initLogger,
   authenticateToken,
   communityModeratorsRouter,
+  setOnlineStatus,
   requestFinally
 );
 
@@ -153,6 +171,7 @@ app.use(
   initLogger,
   authenticateToken,
   communityFlagsRouter,
+  setOnlineStatus,
   requestFinally
 );
 app.use(
@@ -160,6 +179,7 @@ app.use(
   initLogger,
   authenticateToken,
   communityTagsRouter,
+  setOnlineStatus,
   requestFinally
 );
 app.use(
@@ -167,6 +187,7 @@ app.use(
   initLogger,
   authenticateToken,
   communityRulesRouter,
+  setOnlineStatus,
   requestFinally
 );
 app.use(
@@ -174,6 +195,7 @@ app.use(
   initLogger,
   authenticateToken,
   communityMembersRouter,
+  setOnlineStatus,
   requestFinally
 );
 
@@ -182,6 +204,7 @@ app.use(
   initLogger,
   authenticateToken,
   communityRouter,
+  setOnlineStatus,
   requestFinally
 );
 
@@ -190,6 +213,7 @@ app.use(
   initLogger,
   authenticateToken,
   postFlagsRouter,
+  setOnlineStatus,
   requestFinally
 );
 app.use(
@@ -197,15 +221,24 @@ app.use(
   initLogger,
   authenticateToken,
   postTagsRouter,
+  setOnlineStatus,
   requestFinally
 );
-app.use("/api/post", initLogger, authenticateToken, postRouter, requestFinally);
+app.use(
+  "/api/post",
+  initLogger,
+  authenticateToken,
+  postRouter,
+  setOnlineStatus,
+  requestFinally
+);
 
 app.use(
   "/api/comment/reply",
   initLogger,
   authenticateToken,
   commentReplyRouter,
+  setOnlineStatus,
   requestFinally
 );
 app.use(
@@ -213,6 +246,7 @@ app.use(
   initLogger,
   authenticateToken,
   commentVoteRouter,
+  setOnlineStatus,
   requestFinally
 );
 app.use(
@@ -220,6 +254,7 @@ app.use(
   initLogger,
   authenticateToken,
   commentFlagsRouter,
+  setOnlineStatus,
   requestFinally
 );
 app.use(
@@ -227,9 +262,17 @@ app.use(
   initLogger,
   authenticateToken,
   commentRouter,
+  setOnlineStatus,
   requestFinally
 );
 
-app.use("/api/user", initLogger, authenticateToken, userRouter, requestFinally);
+app.use(
+  "/api/user",
+  initLogger,
+  authenticateToken,
+  userRouter,
+  setOnlineStatus,
+  requestFinally
+);
 
 module.exports = app;

--- a/app/server/versions/v1/db/startUp.js
+++ b/app/server/versions/v1/db/startUp.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* 
  Copyright © 2022 Province of British Columbia
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +23,7 @@ const color = require("ansi-colors");
 const Community = require("../models/community.model");
 const Post = require("../models/post.model");
 const Comment = require("../models/comment.model");
+const User = require("../models/user.model");
 const Options = require("../models/options.model");
 
 const optionsCollection = require("./init/optionsCollection");
@@ -83,6 +83,11 @@ const mongoStartUp = async (db, collections) => {
       { "downvotes.count": null },
       { "downvotes.count": 0 }
     );
+  }
+
+  if (collections.includes("user")) {
+    // Set offline status
+    await User.updateMany({ online: true }, { online: false });
   }
 };
 

--- a/app/server/versions/v1/jobs/defineOfflineStatusJob.js
+++ b/app/server/versions/v1/jobs/defineOfflineStatusJob.js
@@ -20,31 +20,23 @@
  * @module
  */
 
-const Community = require("../models/community.model");
+const User = require("../models/user.model");
 
 /**
- * @description Defines the job that removes user's from the kicked array on Community.
+ * @description Defines the job that sets user's offline status.
  * @param agenda Job scheduler, defined in connection.js
  */
-const communityUnKick = async (agenda, community, userId) => {
+const defineOfflineStatusJob = async (agenda, userId) => {
   try {
-    await agenda.define(`communityUnKick-${community}-${userId}`, async () => {
-      await Community.updateOne(
-        { title: community },
-        {
-          $pull: {
-            kicked: {
-              userId,
-            },
-          },
-        }
-      );
-      console.log(`Agenda removed a user from kicked array of ${community}.`);
-      await agenda.cancel(`communityUnKick--${community}-${userId}`);
+    // Cancel offline status job
+    await agenda.cancel({ name: `offlineStatus-${userId}` });
+    // Define offline status job
+    await agenda.define(`offlineStatus-${userId}`, async () => {
+      await User.updateOne({ _id: userId }, { online: false });
     });
   } catch (err) {
-    console.log(`jobs/communityUnKick: ${err}`);
+    console.log(`jobs/defineOfflineStatusJob: ${err}`);
   }
 };
 
-module.exports = communityUnKick;
+module.exports = defineOfflineStatusJob;

--- a/app/server/versions/v1/middleware/setOnlineStatus.js
+++ b/app/server/versions/v1/middleware/setOnlineStatus.js
@@ -1,0 +1,44 @@
+/* 
+ Copyright © 2022 Province of British Columbia
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/**
+ * Application entry point
+ * @author [Brady Mitchell](braden.jr.mitch@gmail.com)
+ * @module
+ */
+
+const ResponseError = require("../classes/responseError");
+const { agenda } = require("../../../db");
+const defineOfflineStatusJob = require("../jobs/defineOfflineStatusJob");
+const User = require("../models/user.model");
+
+const setOnlineStatus = async (req, res, next) => {
+  try {
+    // Set online status
+    await User.updateOne({ _id: req.user.id }, { online: true });
+    // Define job for offline status
+    await defineOfflineStatusJob(agenda, req.user.id);
+    // Reschedule offline status
+    await agenda.schedule("in 5 minutes", `offlineStatus-${req.user.id}`);
+  } catch (err) {
+    if (err instanceof ResponseError)
+      return res.status(err.status).send(err.message);
+    return res.status(400).send(`Bad Request: ${err}`);
+  }
+  next();
+};
+
+module.exports = setOnlineStatus;

--- a/app/server/versions/v1/models/user.model.js
+++ b/app/server/versions/v1/models/user.model.js
@@ -45,6 +45,8 @@
  *          minimum: 8
  *        role:
  *          type: string
+ *        online:
+ *          type: boolean
  *        postCount:
  *          type: number
  *          description: Number of posts user has created.
@@ -133,6 +135,7 @@ const User = new mongoose.Schema(
     password: { type: String },
     refreshToken: { type: String },
     role: { type: String },
+    online: { type: Boolean },
     postCount: { type: Number },
     firstName: { type: String },
     lastName: { type: String },

--- a/app/server/versions/v1/routes/community/communityMembers.js
+++ b/app/server/versions/v1/routes/community/communityMembers.js
@@ -91,7 +91,14 @@ router.get("/:title", async (req, res, next) => {
         $match: { "communities.community": community.title },
       },
       {
-        $project: { _id: 1, username: 1, firstName: 1, lastName: 1, avatar: 1 },
+        $project: {
+          _id: 1,
+          username: 1,
+          firstName: 1,
+          lastName: 1,
+          avatar: 1,
+          online: 1,
+        },
       },
     ]);
 

--- a/app/server/versions/v1/routes/community/communityModerators.js
+++ b/app/server/versions/v1/routes/community/communityModerators.js
@@ -588,31 +588,38 @@ router.post("/kick/:title", async (req, res, next) => {
       );
 
     // Define job for kicking user
-    await communityUnKick(
-      agenda,
-      community.title,
-      kickUser.id,
-      kickUser.username
-    );
+    await communityUnKick(agenda, community.title, kickUser.id);
     switch (req.body.period) {
       // TODO: REMOVE TEST CASE
       case "test":
         periodEnd = moment()
           .add(5, "minutes")
           .format("MMMM Do YYYY, h:mm:ss a");
-        agenda.schedule("in 5 minutes", `communityUnKick-${kickUser.id}`);
+        await agenda.schedule(
+          "in 5 minutes",
+          `communityUnKick-${community.title}-${kickUser.id}`
+        );
         break;
       case "hour":
         periodEnd = moment().add(1, "hour").format("MMMM Do YYYY, h:mm:ss a");
-        agenda.schedule("in 1 hour", `communityUnKick-${kickUser.id}`);
+        await agenda.schedule(
+          "in 1 hour",
+          `communityUnKick-${community.title}-${kickUser.id}`
+        );
         break;
       case "day":
         periodEnd = moment().add(1, "days").format("MMMM Do YYYY, h:mm:ss a");
-        agenda.schedule("in 1 day", `communityUnKick-${kickUser.id}`);
+        await agenda.schedule(
+          "in 1 day",
+          `communityUnKick-${community.title}-${kickUser.id}`
+        );
         break;
       case "week":
         periodEnd = moment().add(1, "week").format("MMMM Do YYYY, h:mm:ss a");
-        agenda.schedule("in 1 week", `communityUnKick-${kickUser.id}`);
+        await agenda.schedule(
+          "in 1 week",
+          `communityUnKick-${community.title}-${kickUser.id}`
+        );
         break;
       case "forever":
         periodEnd = "N/A";

--- a/app/server/versions/v1/routes/onlineStatus.js
+++ b/app/server/versions/v1/routes/onlineStatus.js
@@ -1,0 +1,74 @@
+/* eslint-disable prefer-destructuring */
+/* 
+ Copyright © 2022 Province of British Columbia
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+/**
+ * Application entry point
+ * @author [Brady Mitchell](braden.jr.mitch@gmail.com)
+ * @module
+ */
+
+const express = require("express");
+const findSingleDocuments = require("../functions/findSingleDocuments");
+
+const router = express.Router();
+
+const User = require("../models/user.model");
+
+/**
+ * @swagger
+ * paths:
+ *  /api/online:
+ *    get:
+ *      security:
+ *        - bearerAuth: []
+ *      tags:
+ *        - User
+ *      summary: Check online status.
+ *      description: Doesn't update the user's online status, allowing you to check your own online status.
+ *      responses:
+ *        '404':
+ *          description: User not found.
+ *        '200':
+ *          description: Success.
+ *        '400':
+ *          description: Bad Request.
+ */
+
+// Check online status
+router.get("/", async (req, res, next) => {
+  try {
+    req.log.addAction("Finding user.");
+    const { user } = await findSingleDocuments({
+      user: req.user.username,
+    });
+    req.log.addAction("User found.");
+
+    const onlineUser = await User.aggregate([
+      { $match: { username: user.username } },
+      { $project: { _id: 0, online: 1 } },
+    ]);
+
+    req.log.setResponse(200, "Success");
+    res.status(200).json(onlineUser[0]);
+  } catch (err) {
+    res.locals.err = err;
+  } finally {
+    next();
+  }
+});
+
+module.exports = router;

--- a/app/server/versions/v1/routes/routeImports.js
+++ b/app/server/versions/v1/routes/routeImports.js
@@ -23,6 +23,7 @@ const healthCheckRouter = require("./healthCheck");
 const tokenRouter = require("./token");
 
 const searchRouter = require("./search");
+const onlineStatusRouter = require("./onlineStatus");
 
 module.exports = {
   communityRouter,
@@ -45,4 +46,5 @@ module.exports = {
   healthCheckRouter,
   tokenRouter,
   searchRouter,
+  onlineStatusRouter,
 };

--- a/app/server/versions/v1/routes/search.js
+++ b/app/server/versions/v1/routes/search.js
@@ -149,6 +149,7 @@ router.get("/:query", async (req, res, next) => {
           _id: 1,
           title: 1,
           message: 1,
+          community: 1,
           creatorName: 1,
           creatorUsername: 1,
           createdOn: 1,

--- a/app/server/versions/v1/routes/user.js
+++ b/app/server/versions/v1/routes/user.js
@@ -511,6 +511,7 @@ router.get("/:username", async (req, res, next) => {
       username: user.username,
       email: user.email,
       role: user.role,
+      online: user.online,
       firstName: user.firstName,
       lastName: user.lastName,
       bio: user.bio,


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added `online status` (boolean) to User schema.
- Login and almost all endpoints set the user's online status for **5 minutes**.
- After the 5 minutes if the user hasn't been active they become offline.
- Added online status to **GET /api/user/{username}** to tell if other users are online.
- Added **GET /api/online** to tell if you (current user) is online.
- Online status is set to false on server startup.

- Unkick jobs wouldn't reschedule after server shutdown and startup if they had passed their scheduled run time, so I added a function to compare the current date to the periodEnd date to see if users should be unkicked right away or reschedule for however many hours they had left to wait.

## Requires

Add 'Requires Attention' label if appropriate.

- [ ] Requires an update to the .env file
- [ ] Requires adding a file listed in the .gitignore
- [ ] Requires an opinion or answer to a question, see comments.
- [ ] Requires other attention, see below.

If there are any requirements for the developer to make after this PR is merged please list them here.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested offline status after 5 minutes in swagger. Tested resetting of the 5 minute timer for online status by evoking endpoints. Tested unkick function on server startup.

For pull requests that are not just a simple fix, please check that the branch works on your local machine.

- [ ] Tested by Zach.
- [ ] Tested by Brandon.
- [x] Tested by Brady.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] If attention is required by the developer such as updating the .env file, these requirements have been listed.
